### PR TITLE
POST can have URL parameters and should have "Content-Length" set to 0 when request body is empty

### DIFF
--- a/requests/src/requests/Requester.scala
+++ b/requests/src/requests/Requester.scala
@@ -166,7 +166,7 @@ case class Requester(verb: String,
 
     val url0 = new java.net.URL(url)
 
-    val url1 = if (verb != "POST" && params.nonEmpty) {
+    val url1 = if (params.nonEmpty) {
       val encodedParams = Util.urlEncode(params)
       val firstSep = if (url0.getQuery != null) "&" else "?"
       new java.net.URL(url + firstSep + encodedParams)


### PR DESCRIPTION
1. POST can have URL parameters, it's actually quite common.
2. A lot of web server requires "Content-Length" header set to 0 even when POST request body is empty.
3. remove useless println()