### PR TITLE
Fix test failures in RequestTests

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -17,7 +17,10 @@ class RequestsModule(val crossScalaVersion: String) extends CrossScalaModule wit
     )
   )
   object test extends Tests{
-    def ivyDeps = Agg(ivy"com.lihaoyi::utest::0.6.3")
+    def ivyDeps = Agg(
+      ivy"com.lihaoyi::utest::0.6.3",
+      ivy"com.lihaoyi::ujson::0.7.1"
+    )
     def testFrameworks = Seq("utest.runner.Framework")
   }
 }


### PR DESCRIPTION
This PR addresses issue #25 by fixing all test failures in `RequestTests`:

- The https://httpbin.org site now returns JSON results in an indented format. Instead of using raw string comparison, this PR uses uJson to parse and compare the result.
- Unfortunately, https://doesnt-exist.com does exist and it uses a proper certificate. Switched to https://expired.badssl.com for the invalid certificate test.