### PR TITLE
Fix default auth param in Request object causing NullPointerException

### DIFF
--- a/requests/src/requests/Model.scala
+++ b/requests/src/requests/Model.scala
@@ -43,7 +43,7 @@ object Compress{
   * [[Request]].
   */
 case class Request(url: String,
-                   auth: RequestAuth = null,
+                   auth: RequestAuth = RequestAuth.Empty,
                    params: Iterable[(String, String)] = Nil,
                    headers: Iterable[(String, String)] = Nil,
                    readTimeout: Int = 0,


### PR DESCRIPTION
When a reusable `Request` object used across various requests (using `get` methods etc.), if the `auth` parameter is not provided to `Request` constructor, the call to making HTTP requests fail with a `NullPointerException`. For other overloads of HTTP request methods which take all parameters separately, the values coming from current session is used and the `auth` parameter in `Session` is initialized with `RequestAuth.Empty` by default. Here, I reflected that default value to the parameter `auth` in constructor of `Request` case class.