### PR TITLE
update streaming doc for latest version

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -141,11 +141,9 @@ r.contents
 ## Streaming Requests
 
 ```scala
-requests.get.stream("https://api.github.com/events")(
-  onDownload = inputStream => {
-    inputStream.transferTo(new java.io.FileOutputStream("file.json"))
-  }
-)
+requests.get
+  .stream("https://api.github.com/events")
+  .readBytesThrough(_.transferTo(new java.io.FileOutputStream("file.json")))
 ```
 
 Requests exposes the `requests.get.stream` (and equivalent


### PR DESCRIPTION
This API seems to have disappeared
```scala
requests.get.stream("https://api.github.com/events")(
  onUpload = outputStream => {...},
  onHeadersReceived = streamHeaders => {...}
  onDownload = inputStream => {...}
)
```

Note that this update does not cover all the change in API.