### PR TITLE
Upgrade geny to version 0.5.0

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -17,7 +17,7 @@ class RequestsModule(val crossScalaVersion: String) extends CrossScalaModule wit
     )
   )
   def ivyDeps = Agg(
-    ivy"com.lihaoyi::geny::0.4.2"
+    ivy"com.lihaoyi::geny::0.5.0"
   )
   object test extends Tests{
     def ivyDeps = Agg(


### PR DESCRIPTION
This fixes binary compatibility to the latest versions of cask, and os-lib which already use 0.5.0.

See #49 