### PR TITLE
Infer Content-Type to be application/json when ujson values are provided

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -17,12 +17,12 @@ class RequestsModule(val crossScalaVersion: String) extends CrossScalaModule wit
     )
   )
   def ivyDeps = Agg(
-    ivy"com.lihaoyi::geny::0.5.0"
+    ivy"com.lihaoyi::geny::0.5.0",
+    ivy"com.lihaoyi::ujson::0.9.7"
   )
   object test extends Tests{
     def ivyDeps = Agg(
-      ivy"com.lihaoyi::utest::0.7.3",
-      ivy"com.lihaoyi::ujson::0.9.7"
+      ivy"com.lihaoyi::utest::0.7.3"
     )
     def testFrameworks = Seq("utest.runner.Framework")
   }

--- a/build.sc
+++ b/build.sc
@@ -18,7 +18,7 @@ class RequestsModule(val crossScalaVersion: String) extends CrossScalaModule wit
   )
   def ivyDeps = Agg(
     ivy"com.lihaoyi::geny::0.5.0",
-    ivy"com.lihaoyi::ujson::0.9.7"
+    ivy"com.lihaoyi::ujson::1.0.0"
   )
   object test extends Tests{
     def ivyDeps = Agg(

--- a/requests/src/requests/Model.scala
+++ b/requests/src/requests/Model.scala
@@ -76,9 +76,13 @@ object RequestBlob{
 
   implicit class ByteSourceRequestBlob[T](x: T)(implicit f: T => geny.Writable) extends RequestBlob{
     private[this] val s = f(x)
-    override def headers = super.headers ++ Seq(
-      "Content-Type" -> "application/octet-stream"
-    )
+    override def headers = {
+      val contentType = s match {
+        case _: ujson.Value => "application/json"
+        case _ => "application/octet-stream"
+      }
+      super.headers ++ Seq("Content-Type" -> contentType)
+    }
     def write(out: java.io.OutputStream) = s.writeBytesTo(out)
   }
   implicit class FileRequestBlob(x: java.io.File) extends RequestBlob{

--- a/requests/test/src/requests/RequestTests.scala
+++ b/requests/test/src/requests/RequestTests.scala
@@ -220,5 +220,11 @@ object RequestTests extends TestSuite{
         }
       }
     }
+    test("blob content type") {
+      test("json") {
+        val blob: RequestBlob = Obj("k" -> "v")
+        assert(blob.headers.contains("Content-Type" -> "application/json"))
+      }
+    }
   }
 }


### PR DESCRIPTION
This PR addresses #55 by setting the `Content-Type` header to be `application/json` when `ujson` values are provided as POST data.

Please note that this change adds `ujson` as a dependency of `requests-scala` (it was only listed as a test dependency before this PR).