### PR TITLE
Support for custom SSLContext for ssl configuration

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -445,6 +445,17 @@ requests.get(
 )
 ```
 
+You can also use a sslContext to provide a more customized ssl configuration
+
+```scala
+val sslContext: SSLContext = //initialized sslContext
+
+requests.get(
+  "https://client.badssl.com",
+  sslcontext = sslContext
+)
+```
+
 ## Sessions
 
 A `requests.Session` automatically handles sending/receiving/persisting cookies

--- a/requests/src/requests/Model.scala
+++ b/requests/src/requests/Model.scala
@@ -9,6 +9,8 @@ import java.io.OutputStream
 import java.nio.charset.Charset
 import java.util.zip.{DeflaterOutputStream, GZIPOutputStream}
 
+import javax.net.ssl.SSLContext
+
 /**
   * Mechanisms for compressing the upload stream; supports Gzip and Deflate
   * by default
@@ -50,6 +52,7 @@ case class Request(url: String,
                    connectTimeout: Int = 0,
                    proxy: (String, Int) = null,
                    cert: Cert = null,
+                   sslContext: SSLContext = null,
                    cookies: Map[String, HttpCookie] = Map(),
                    cookieValues: Map[String, String] = Map(),
                    maxRedirects: Int = 5,

--- a/requests/src/requests/Session.scala
+++ b/requests/src/requests/Session.scala
@@ -1,6 +1,8 @@
 package requests
 import java.net.HttpCookie
 
+import javax.net.ssl.SSLContext
+
 import scala.collection.mutable
 
 /**
@@ -26,6 +28,7 @@ case class Session(headers: Map[String, String] = BaseSession.defaultHeaders,
                    auth: RequestAuth = RequestAuth.Empty,
                    proxy: (String, Int) = null,
                    cert: Cert = null,
+                   sslContext: SSLContext = null,
                    persistCookies: Boolean = true,
                    maxRedirects: Int = 5,
                    readTimeout: Int = 10 * 1000,

--- a/requests/src/requests/package.scala
+++ b/requests/src/requests/package.scala
@@ -1,5 +1,7 @@
 import java.net.HttpCookie
 
+import javax.net.ssl.SSLContext
+
 import scala.collection.mutable
 
 package object requests extends _root_.requests.BaseSession {
@@ -12,6 +14,8 @@ package object requests extends _root_.requests.BaseSession {
   def proxy = null
 
   def cert: Cert = null
+
+  def sslContext: SSLContext = null
 
   def maxRedirects: Int = 5
 

--- a/requests/test/src/requests/FileUtils.scala
+++ b/requests/test/src/requests/FileUtils.scala
@@ -11,7 +11,7 @@ object FileUtils {
     val stream: InputStream = new FileInputStream(keyStorePath)
     val sslContext = SSLContext.getInstance("TLS")
 
-    val keyManagerFactory = KeyManagerFactory.getInstance("SunX509")
+    val keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm)
     val keyStore = KeyStore.getInstance("PKCS12")
     keyStore.load(stream, keyStorePassword.toCharArray)
     keyManagerFactory.init(keyStore, keyStorePassword.toCharArray)

--- a/requests/test/src/requests/FileUtils.scala
+++ b/requests/test/src/requests/FileUtils.scala
@@ -1,0 +1,24 @@
+package requests
+
+import java.io.{FileInputStream, InputStream}
+import java.security.{KeyStore, SecureRandom}
+
+import javax.net.ssl.{KeyManagerFactory, SSLContext}
+
+object FileUtils {
+
+  def createSslContext(keyStorePath: String, keyStorePassword: String): SSLContext = {
+    val stream: InputStream = new FileInputStream(keyStorePath)
+    val sslContext = SSLContext.getInstance("TLS")
+
+    val keyManagerFactory = KeyManagerFactory.getInstance("SunX509")
+    val keyStore = KeyStore.getInstance("PKCS12")
+    keyStore.load(stream, keyStorePassword.toCharArray)
+    keyManagerFactory.init(keyStore, keyStorePassword.toCharArray)
+    sslContext.init(keyManagerFactory.getKeyManagers, null, new SecureRandom())
+    stream.close()
+
+    sslContext
+  }
+
+}

--- a/requests/test/src/requests/RequestTests.scala
+++ b/requests/test/src/requests/RequestTests.scala
@@ -245,6 +245,17 @@ object RequestTests extends TestSuite{
         else
           assert(res.statusCode == 200)
       }
+      test("sslContext"){
+        val res = requests.get(
+          "https://client.badssl.com",
+          sslContext = FileUtils.createSslContext(s"$base/badssl.com-client.p12", "badssl.com"),
+          check = false
+        )
+        if (res.statusCode == 400)
+          println(s"WARNING: Certificate may have expired and needs to be updated. Please check: $instruction and/or file issue")
+        else
+          assert(res.statusCode == 200)
+      }
       test("noCert"){
         val res = requests.get(
           "https://client.badssl.com",

--- a/requests/test/src/requests/RequestTests.scala
+++ b/requests/test/src/requests/RequestTests.scala
@@ -222,15 +222,17 @@ object RequestTests extends TestSuite{
     }
     test("clientCertificate"){
       val base = "./requests/test/resources"
+      val url = "https://client.badssl.com"
       val instruction = "https://github.com/lihaoyi/requests-scala/blob/master/requests/test/resources/badssl.com-client.md"
+      val certificateExpiredMessage = s"WARNING: Certificate may have expired and needs to be updated. Please check: $instruction and/or file issue"
       test("passwordProtected"){
         val res = requests.get(
-          "https://client.badssl.com",
+          url,
           cert = (s"$base/badssl.com-client.p12", "badssl.com"),
           check = false
         )
         if (res.statusCode == 400)
-          println(s"WARNING: Certificate may have expired and needs to be updated. Please check: $instruction and/or file issue")
+          println(certificateExpiredMessage)
         else
           assert(res.statusCode == 200)
       }
@@ -241,7 +243,7 @@ object RequestTests extends TestSuite{
           check = false
         )
         if (res.statusCode == 400)
-          println(s"WARNING: Certificate may have expired and needs to be updated. Please check: $instruction and/or file issue")
+          println(certificateExpiredMessage)
         else
           assert(res.statusCode == 200)
       }
@@ -252,7 +254,7 @@ object RequestTests extends TestSuite{
           check = false
         )
         if (res.statusCode == 400)
-          println(s"WARNING: Certificate may have expired and needs to be updated. Please check: $instruction and/or file issue")
+          println(certificateExpiredMessage)
         else
           assert(res.statusCode == 200)
       }


### PR DESCRIPTION
Requests-scala already supports client side certificates, but it doesn't have the support for a more customisable ssl configuration. Providing a sslcontext option within the request parameter will enable the user to use a custom keymanager and trustmanager within the sslcontext. This will enable the user to load x amount of custom key materials and/or x amount of custom trust materials. 

You can use it like this:
```scala
val sslContext: SSLContext = //initialized sslContext

requests.get(
  "https://client.badssl.com",
  sslcontext = sslContext
)
```

This pull requests will close issue https://github.com/lihaoyi/requests-scala/issues/61