### PR TITLE
Prepare for inclusion in dotty-community build

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -2,7 +2,9 @@ import mill._
 import mill.scalalib.publish.{Developer, License, PomSettings, VersionControl}
 import scalalib._
 
-object requests extends Cross[RequestsModule]("2.12.6", "2.13.0")
+val dottyVersion = Option(sys.props("dottyVersion"))
+
+object requests extends Cross[RequestsModule]((List("2.12.6", "2.13.0", "0.26.0-RC1") ++ dottyVersion): _*)
 class RequestsModule(val crossScalaVersion: String) extends CrossScalaModule with PublishModule {
   def publishVersion = "0.6.5"
   def artifactName = "requests"
@@ -21,7 +23,7 @@ class RequestsModule(val crossScalaVersion: String) extends CrossScalaModule wit
   )
   object test extends Tests{
     def ivyDeps = Agg(
-      ivy"com.lihaoyi::utest::0.7.3",
+      ivy"com.lihaoyi::utest::0.7.4",
       ivy"com.lihaoyi::ujson::1.1.0"
     )
     def testFrameworks = Seq("utest.runner.Framework")

--- a/mill
+++ b/mill
@@ -3,7 +3,7 @@
 # This is a wrapper script, that automatically download mill from GitHub release pages
 # You can give the required mill version with MILL_VERSION env variable
 # If no version is given, it falls back to the value of DEFAULT_MILL_VERSION
-DEFAULT_MILL_VERSION=0.7.3
+DEFAULT_MILL_VERSION=0.8.0
 
 set -e
 

--- a/requests/src/requests/Model.scala
+++ b/requests/src/requests/Model.scala
@@ -244,7 +244,7 @@ object RequestAuth{
   object Empty extends RequestAuth{
     def header = None
   }
-  implicit def implicitBasic(x: (String, String)) = new Basic(x._1, x._2)
+  implicit def implicitBasic(x: (String, String)): Basic = new Basic(x._1, x._2)
   class Basic(username: String, password: String) extends RequestAuth{
     def header = Some("Basic " + java.util.Base64.getEncoder.encodeToString((username + ":" + password).getBytes()))
   }
@@ -258,7 +258,7 @@ object RequestAuth{
 
 sealed trait Cert
 object Cert{
-  implicit def implicitP12(path: String) = P12(path, None)
-  implicit def implicitP12(x: (String, String)) = P12(x._1, Some(x._2))
+  implicit def implicitP12(path: String): P12 = P12(path, None)
+  implicit def implicitP12(x: (String, String)): P12 = P12(x._1, Some(x._2))
   case class P12(p12: String, pwd: Option[String] = None) extends Cert
 }

--- a/requests/src/requests/Requester.scala
+++ b/requests/src/requests/Requester.scala
@@ -187,21 +187,21 @@ case class Requester(verb: String,
             url1.openConnection(p)
           }
 
-      connection = conn match{
-        case c: HttpsURLConnection =>
-          if (cert != null) {
-            c.setSSLSocketFactory(Util.clientCertSocketFactory(cert, verifySslCerts))
-            if (!verifySslCerts) c.setHostnameVerifier((_: String, _: SSLSession) => true)
-          } else if (sslContext != null) {
-            c.setSSLSocketFactory(sslContext.getSocketFactory)
-            if (!verifySslCerts) c.setHostnameVerifier((_: String, _: SSLSession) => true)
-          } else if (!verifySslCerts) {
-            c.setSSLSocketFactory(Util.noVerifySocketFactory)
-            c.setHostnameVerifier((_: String, _: SSLSession) => true)
-          }
-          c
-        case c: HttpURLConnection => c
-      }
+        connection = conn match{
+          case c: HttpsURLConnection =>
+            if (cert != null) {
+              c.setSSLSocketFactory(Util.clientCertSocketFactory(cert, verifySslCerts))
+              if (!verifySslCerts) c.setHostnameVerifier((_: String, _: SSLSession) => true)
+            } else if (sslContext != null) {
+              c.setSSLSocketFactory(sslContext.getSocketFactory)
+              if (!verifySslCerts) c.setHostnameVerifier((_: String, _: SSLSession) => true)
+            } else if (!verifySslCerts) {
+              c.setSSLSocketFactory(Util.noVerifySocketFactory)
+              c.setHostnameVerifier((_: String, _: SSLSession) => true)
+            }
+            c
+          case c: HttpURLConnection => c
+        }
 
         connection.setInstanceFollowRedirects(false)
         val upperCaseVerb = verb.toUpperCase

--- a/requests/test/src/requests/RequestTests.scala
+++ b/requests/test/src/requests/RequestTests.scala
@@ -33,7 +33,7 @@ object RequestTests extends TestSuite{
     test("params"){
       test("get"){
         // All in URL
-        val res1 = requests.get("https://httpbin.org/get?hello=world&foo=baz").text
+        val res1 = requests.get("https://httpbin.org/get?hello=world&foo=baz").text()
         assert(read(res1).obj("args") == Obj("foo" -> "baz", "hello" -> "world"))
 
         // All in params
@@ -47,7 +47,7 @@ object RequestTests extends TestSuite{
         val res3 = requests.get(
           "https://httpbin.org/get?hello=world",
           params = Map("foo" -> "baz")
-        ).text
+        ).text()
         assert(read(res3).obj("args") == Obj("foo" -> "baz", "hello" -> "world"))
 
         // Needs escaping
@@ -63,7 +63,7 @@ object RequestTests extends TestSuite{
             "https://httpbin.org/post",
             data = Map("hello" -> "world", "foo" -> "baz"),
             chunkedUpload = chunkedUpload
-          ).text
+          ).text()
           assert(read(res1).obj("form") == Obj("foo" -> "baz", "hello" -> "world"))
         }
       }
@@ -73,7 +73,7 @@ object RequestTests extends TestSuite{
             "https://httpbin.org/put",
             data = Map("hello" -> "world", "foo" -> "baz"),
             chunkedUpload = chunkedUpload
-          ).text
+          ).text()
           assert(read(res1).obj("form") == Obj("foo" -> "baz", "hello" -> "world"))
         }
       }
@@ -87,7 +87,7 @@ object RequestTests extends TestSuite{
             MultiItem("file2", "Goodbye!")
           ),
           chunkedUpload = chunkedUpload
-        ).text
+        ).text()
 
         assert(read(response).obj("files") == Obj("file1" -> "Hello!"))
         assert(read(response).obj("form") == Obj("file2" -> "Goodbye!"))
@@ -97,17 +97,17 @@ object RequestTests extends TestSuite{
 
       test("session"){
         val s = requests.Session(cookieValues = Map("hello" -> "world"))
-        val res1 = s.get("https://httpbin.org/cookies").text.trim
+        val res1 = s.get("https://httpbin.org/cookies").text().trim
         assert(read(res1) == Obj("cookies" -> Obj("hello" -> "world")))
         s.get("https://httpbin.org/cookies/set?freeform=test")
-        val res2 = s.get("https://httpbin.org/cookies").text.trim
+        val res2 = s.get("https://httpbin.org/cookies").text().trim
         assert(read(res2) == Obj("cookies" -> Obj("freeform" -> "test", "hello" -> "world")))
       }
       test("raw"){
-        val res1 = requests.get("https://httpbin.org/cookies").text.trim
+        val res1 = requests.get("https://httpbin.org/cookies").text().trim
         assert(read(res1) == Obj("cookies" -> Obj()))
         requests.get("https://httpbin.org/cookies/set?freeform=test")
-        val res2 = requests.get("https://httpbin.org/cookies").text.trim
+        val res2 = requests.get("https://httpbin.org/cookies").text().trim
         assert(read(res2) == Obj("cookies" -> Obj()))
       }
     }
@@ -134,9 +134,9 @@ object RequestTests extends TestSuite{
       }
     }
     test("streaming"){
-      val res1 = requests.get("http://httpbin.org/stream/5").text
+      val res1 = requests.get("http://httpbin.org/stream/5").text()
       assert(res1.linesIterator.length == 5)
-      val res2 = requests.get("http://httpbin.org/stream/52").text
+      val res2 = requests.get("http://httpbin.org/stream/52").text()
       assert(res2.linesIterator.length == 52)
     }
     test("timeouts"){
@@ -171,7 +171,7 @@ object RequestTests extends TestSuite{
     }
     test("decompress"){
       val res1 = requests.get("https://httpbin.org/gzip")
-      assert(read(res1.text).obj("headers").obj("Host").str == "httpbin.org")
+      assert(read(res1.text()).obj("headers").obj("Host").str == "httpbin.org")
 
       val res2 = requests.get("https://httpbin.org/deflate")
       assert(read(res2).obj("headers").obj("Host").str == "httpbin.org")
@@ -190,26 +190,26 @@ object RequestTests extends TestSuite{
         compress = requests.Compress.None,
         data = "Hello World"
       )
-      assert(res1.text.contains(""""Hello World""""))
+      assert(res1.text().contains(""""Hello World""""))
 
       val res2 = requests.post(
         "https://httpbin.org/post",
         compress = requests.Compress.Gzip,
         data = "I am cow"
       )
-      assert(res2.text.contains("data:application/octet-stream;base64,H4sIAAAAAAAAAA=="))
+      assert(res2.text().contains("data:application/octet-stream;base64,H4sIAAAAAAAAAA=="))
 
       val res3 = requests.post(
         "https://httpbin.org/post",
         compress = requests.Compress.Deflate,
         data = "Hear me moo"
       )
-      assert(res3.text.contains("data:application/octet-stream;base64,eJw="))
-      res3.text
+      assert(res3.text().contains("data:application/octet-stream;base64,eJw="))
+      res3.text()
     }
     test("headers"){
       test("default"){
-        val res = requests.get("https://httpbin.org/headers").text
+        val res = requests.get("https://httpbin.org/headers").text()
         val hs = read(res)("headers").obj
         assert(hs("User-Agent").str == "requests-scala")
         assert(hs("Accept-Encoding").str == "gzip, deflate")


### PR DESCRIPTION
Mostly minor changes to make it compatible with Dotty:

- allow passing in the Dotty version through a system property, as is done conventionally by the community build
- upgrade to mill > 0.7.3, as this version includes a fix necessary for publishing Dotty projects locally (required for downstream projects)
- add the empty parameter list to calls to geny's `text()` method. On a side note, @lihaoyi, since Dotty requires specifying empty param lists, should geny add an overload to `text` without any parameter list?

cc @anatoliykmetyuk

fyi @manojo, maybe the outline to the build will help for the ScalaTags port too