### PR TITLE
Quote cookie values

### DIFF
--- a/requests/src/requests/Requester.scala
+++ b/requests/src/requests/Requester.scala
@@ -247,7 +247,7 @@ case class Requester(verb: String,
           connection.setRequestProperty(
             "Cookie",
             allCookies
-              .map{case (k, v) => k + "=" + v}
+              .map{case (k, v) => s"""$k="$v""""}
               .mkString("; ")
           )
         }

--- a/requests/test/src/requests/RequestTests.scala
+++ b/requests/test/src/requests/RequestTests.scala
@@ -110,6 +110,14 @@ object RequestTests extends TestSuite{
         val res2 = requests.get("https://httpbin.org/cookies").text().trim
         assert(read(res2) == Obj("cookies" -> Obj()))
       }
+      test("space"){
+        val s = requests.Session(cookieValues = Map("hello" -> "hello, world"))
+        val res1 = s.get("https://httpbin.org/cookies").text().trim
+        assert(read(res1) == Obj("cookies" -> Obj("hello" -> "hello, world")))
+        s.get("https://httpbin.org/cookies/set?freeform=test+test")
+        val res2 = s.get("https://httpbin.org/cookies").text().trim
+        assert(read(res2) == Obj("cookies" -> Obj("freeform" -> "test test", "hello" -> "hello, world")))
+      }
     }
     // Tests fail with 'Request to https://httpbin.org/absolute-redirect/4 failed with status code 404'
     // test("redirects"){


### PR DESCRIPTION
According to [RFC2019](https://tools.ietf.org/html/rfc2109), this is required for values containing spaces, and is always safe for non-space containing values.

Note that most webservers are quite smart and lenient when parsing cookie headers. This change however is still useful for servers that are very strict (such as undertow).