### PR TITLE
chore: Upgrade test deps to ensure compatibility with Scala Native

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.mill linguist-language=Scala

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -41,17 +41,20 @@ jobs:
           sed -i '' 's#//| mill-jvm-version: 17#//| mill-jvm-version: ${{ matrix.java }}#' build.mill
           ./mill -i -DscalaNextVersion=${{ env.SCALA_NEXT_VERSION }} __.publishArtifacts + __.test
 
-  test-windows:
-    needs: [test-linux, test-macos]
-    runs-on: windows-latest
-    strategy:
-      matrix:
-        java: ['17'] # Please match to `mill-jvm-version` in build.mill for Windows since no `sed` command is applied to it
-    steps:
-      - uses: actions/checkout@v6
-      - name: Run tests
-        run: |
-          .\mill -i "-DscalaNextVersion=${{ env.SCALA_NEXT_VERSION }}" __.publishArtifacts + __.test
+  # Failed to parse `license.zip` on Windows CI, needs further investigation, see
+  # https://github.com/com-lihaoyi/requests-scala/actions/runs/24759357647/job/72439599258#step:3:1045
+  #
+  # test-windows:
+  #   needs: [test-linux, test-macos]
+  #   runs-on: windows-latest
+  #   strategy:
+  #     matrix:
+  #       java: ['17'] # Please match to `mill-jvm-version` in build.mill for Windows since no `sed` command is applied to it
+  #   steps:
+  #     - uses: actions/checkout@v6
+  #     - name: Run tests
+  #       run: |
+  #         .\mill -i "-DscalaNextVersion=${{ env.SCALA_NEXT_VERSION }}" __.publishArtifacts + __.test
 
   check-binary-compatibility:
     runs-on: ubuntu-latest

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -21,24 +21,24 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: ['11', '17', '21', '25']
+        java: ['17', '21', '25']
     steps:
       - uses: actions/checkout@v6
       - name: Run tests
         run: |
-          sed -i 's#//| mill-jvm-version: 11#//| mill-jvm-version: ${{ matrix.java }}#' build.mill
+          sed -i 's#//| mill-jvm-version: 17#//| mill-jvm-version: ${{ matrix.java }}#' build.mill
           ./mill -i -DscalaNextVersion=${{ env.SCALA_NEXT_VERSION }} __.publishArtifacts + __.test
 
   test-macos:
     runs-on: macos-latest
     strategy:
       matrix:
-        java: ['25']
+        java: ['17', '21', '25']
     steps:
       - uses: actions/checkout@v6
       - name: Run tests
         run: |
-          sed -i '' 's#//| mill-jvm-version: 11#//| mill-jvm-version: ${{ matrix.java }}#' build.mill
+          sed -i '' 's#//| mill-jvm-version: 17#//| mill-jvm-version: ${{ matrix.java }}#' build.mill
           ./mill -i -DscalaNextVersion=${{ env.SCALA_NEXT_VERSION }} __.publishArtifacts + __.test
 
   test-windows:
@@ -46,7 +46,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        java: ['11'] # Please match to `mill-jvm-version` in build.mill for Windows
+        java: ['17'] # Please match to `mill-jvm-version` in build.mill for Windows
     steps:
       - uses: actions/checkout@v6
       - name: Run tests

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch: # be able to manually trigger a workflow run
 
 env:
-  SCALA_NEXT_VERSION: '3.6.2'
+  SCALA_NEXT_VERSION: '3.7.4'
   # TODO: perherps, it would be nice to allow failure on `SCALA_NEXT_VERSION` as a warning
   #       to avoid too strict dev experiences in the future improvements.
 

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch: # be able to manually trigger a workflow run
 
 env:
-  SCALA_NEXT_VERSION: '3.8.3'
+  SCALA_NEXT_VERSION: '3.6.2'
   # TODO: perherps, it would be nice to allow failure on `SCALA_NEXT_VERSION` as a warning
   #       to avoid too strict dev experiences in the future improvements.
 
@@ -46,12 +46,12 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        java: ['17'] # Please match to `mill-jvm-version` in build.mill for Windows
+        java: ['17'] # Please match to `mill-jvm-version` in build.mill for Windows since no `sed` command is applied to it
     steps:
       - uses: actions/checkout@v6
       - name: Run tests
         run: |
-          .\mill -i -DscalaNextVersion=${{ env.SCALA_NEXT_VERSION }} __.publishArtifacts + __.test
+          .\mill -i "-DscalaNextVersion=${{ env.SCALA_NEXT_VERSION }}" __.publishArtifacts + __.test
 
   check-binary-compatibility:
     runs-on: ubuntu-latest

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -12,22 +12,46 @@ on:
   workflow_dispatch: # be able to manually trigger a workflow run
 
 env:
-  SCALA_NEXT_VERSION: '3.6.2'
+  SCALA_NEXT_VERSION: '3.8.3'
   # TODO: perherps, it would be nice to allow failure on `SCALA_NEXT_VERSION` as a warning
   #       to avoid too strict dev experiences in the future improvements.
 
 jobs:
-  test:
+  test-linux:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: ['11', '17', '21']
+        java: ['11', '17', '21', '25']
     steps:
       - uses: actions/checkout@v4
       - name: Run tests
         run: |
           sed -i 's#//| mill-jvm-version: 11#//| mill-jvm-version: ${{ matrix.java }}#' build.mill
           ./mill -i -DscalaNextVersion=${{ env.SCALA_NEXT_VERSION }} __.publishArtifacts + __.test
+
+  test-macos:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        java: ['25']
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run tests
+        run: |
+          sed -i 's#//| mill-jvm-version: 11#//| mill-jvm-version: ${{ matrix.java }}#' build.mill
+          ./mill -i -DscalaNextVersion=${{ env.SCALA_NEXT_VERSION }} __.publishArtifacts + __.test
+
+  test-windows:
+    needs: [test-linux, test-macos]
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        java: ['11'] # Please match to `mill-jvm-version` in build.mill for Windows
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run tests
+        run: |
+          .\mill -i -DscalaNextVersion=${{ env.SCALA_NEXT_VERSION }} __.publishArtifacts + __.test
 
   check-binary-compatibility:
     runs-on: ubuntu-latest
@@ -40,7 +64,7 @@ jobs:
 
   publish-sonatype:
     if: github.repository == 'com-lihaoyi/requests-scala' && contains(github.ref, 'refs/tags/')
-    needs: test
+    needs: test-linux
     runs-on: ubuntu-latest
     env:
       MILL_SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Run tests
         run: |
-          sed -i 's#//| mill-jvm-version: 17#//| mill-jvm-version: ${{ matrix.java }}#' build.mill
+          sed -i 's#//| mill-jvm-version: 25#//| mill-jvm-version: ${{ matrix.java }}#' build.mill
           ./mill -i -DscalaNextVersion=${{ env.SCALA_NEXT_VERSION }} __.publishArtifacts + __.test
 
   test-macos:
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Run tests
         run: |
-          sed -i '' 's#//| mill-jvm-version: 17#//| mill-jvm-version: ${{ matrix.java }}#' build.mill
+          sed -i '' 's#//| mill-jvm-version: 25#//| mill-jvm-version: ${{ matrix.java }}#' build.mill
           ./mill -i -DscalaNextVersion=${{ env.SCALA_NEXT_VERSION }} __.publishArtifacts + __.test
 
   # Failed to parse `license.zip` on Windows CI, needs further investigation, see

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         java: ['11', '17', '21', '25']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Run tests
         run: |
           sed -i 's#//| mill-jvm-version: 11#//| mill-jvm-version: ${{ matrix.java }}#' build.mill
@@ -35,10 +35,10 @@ jobs:
       matrix:
         java: ['25']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Run tests
         run: |
-          sed -i 's#//| mill-jvm-version: 11#//| mill-jvm-version: ${{ matrix.java }}#' build.mill
+          sed -i '' 's#//| mill-jvm-version: 11#//| mill-jvm-version: ${{ matrix.java }}#' build.mill
           ./mill -i -DscalaNextVersion=${{ env.SCALA_NEXT_VERSION }} __.publishArtifacts + __.test
 
   test-windows:
@@ -48,7 +48,7 @@ jobs:
       matrix:
         java: ['11'] # Please match to `mill-jvm-version` in build.mill for Windows
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Run tests
         run: |
           .\mill -i -DscalaNextVersion=${{ env.SCALA_NEXT_VERSION }} __.publishArtifacts + __.test
@@ -56,7 +56,7 @@ jobs:
   check-binary-compatibility:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Check Binary Compatibility
@@ -76,10 +76,9 @@ jobs:
       LC_ALL: "en_US.UTF-8"
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Publish to Maven Central
         run: ./mill -i mill.scalalib.SonatypeCentralPublishModule/
-
       - name: Create GitHub Release
         id: create_gh_release
         uses: actions/create-release@v1.1.4

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -10,3 +10,9 @@ assumeStandardLibraryStripMargin = true
 docstrings.style = Asterisk
 
 project.git = true
+
+fileOverride {
+  "glob:**/*.mill" = {
+    runner.dialect = scala3
+  }
+}

--- a/build.mill
+++ b/build.mill
@@ -1,7 +1,7 @@
 //| mill-version: 1.1.5
-//| mill-jvm-version: 11
+//| mill-jvm-version: 17
 //| mvnDeps:
-//| - com.github.lolgab::mill-mima_mill1:0.2.0
+//| - com.github.lolgab::mill-mima_mill1:0.2.1
 package build
 
 import java.io.FileOutputStream

--- a/build.mill
+++ b/build.mill
@@ -84,13 +84,12 @@ object requests extends Module {
     }
 
     val platfrom =
-      if Properties.isLinux then "linux"
-      else if Properties.isWin then "windows"
-      else if Properties.isMac then "darwin"
+      if (Properties.isLinux) "linux"
+      else if (Properties.isWin) "windows"
+      else if (Properties.isMac) "darwin"
       else sys.error(s"Unsupported platform ${Properties.osName}")
     val arch =
-      if Properties.isMac
-      then
+      if (Properties.isMac)
         "all"
       else
         System.getProperty("os.arch") match
@@ -98,19 +97,19 @@ object requests extends Module {
           case "x86_64" => "amd64"
           case "amd64" => "amd64"
           case other => sys.error(s"Unsupported architecture: ${other}")
+    val ext = if (Properties.isWin) "zip" else "tar.gz"
     val prefix = s"https://github.com/mccutchen/go-httpbin/releases/download/v${goHttpBinVersion}"
     val checksumUrl = s"${prefix}/checksums.txt"
-    val archiveName = s"go-httpbin-${platfrom}-${arch}.tar.gz"
+    val archiveName = s"go-httpbin-${platfrom}-${arch}.${ext}"
     val archiveUrl = s"${prefix}/${archiveName}"
-    val archivePath = destDir / "go-httpbin.tar.gz"
+    val archivePath = destDir / s"go-httpbin.${ext}"
     val checksum = req.get(checksumUrl).lines()
       .find(_.endsWith(archiveName))
       .flatMap(_.split(" ").headOption)
       .getOrElse(sys.error(s"Could not find checksum for ${archiveName}"))
 
     val isDownload =
-      if !os.exists(archivePath)
-      then true
+      if (!os.exists(archivePath)) true
       else calcChecksum(archivePath) != checksum
     if (isDownload) {
       req.get.stream(archiveUrl).writeBytesTo(new FileOutputStream(archivePath.toString))
@@ -118,9 +117,13 @@ object requests extends Module {
       if (localChecksum != checksum)
         sys.error(s"Checksum (${localChecksum}) of downloaded archive (${archiveUrl}) does not match expected ${checksum}")
     }
-    os.proc("tar", "xzf", archivePath, "-C", destDir).call()
+    if (Properties.isWin) {
+      os.proc("unzip", archivePath, "-d", destDir).call()
+    } else {
+      os.proc("tar", "xzf", archivePath, "-C", destDir).call()
+    }
 
-    val targetExecBin = destDir / "go-httpbin"
+    val targetExecBin = destDir / (if (Properties.isWin) "go-httpbin.exe" else "go-httpbin")
     if (!os.exists(targetExecBin) || !os.isExecutable(targetExecBin))
       sys.error(s"Expected to find executable `go-httpbin` in ${destDir}, but it was not.")
     PathRef(targetExecBin)

--- a/build.mill
+++ b/build.mill
@@ -136,7 +136,7 @@ trait RequestsTestModule extends TestModule.Utest {
 object requests extends Module {
   object jvm extends Cross[RequestsJvmModule](scalaVersions)
   trait RequestsJvmModule extends RequestsCrossScalaModule {
-    object test extends ScalaTests with RequestsTestModul
+    object test extends ScalaTests with RequestsTestModule
   }
 
   // // Scala Native is only supported for Scala 3

--- a/build.mill
+++ b/build.mill
@@ -24,6 +24,7 @@ val scalaNextVersion = sys.props.get("scalaNextVersion").toList
 val scalaVersions = List("2.12.20", "2.13.15", "3.3.7") ++ scalaNextVersion ++ communityBuildDottyVersion
 val scala3Versions = scalaVersions.filter(_.startsWith("3"))
 val scalaNativeVer = "0.5.10"
+val goHttpBinVersion = "2.22.1"
 
 trait MimaCheck extends Mima {
   def mimaPreviousVersions = Seq("0.6.9", "0.7.0", "0.7.1", "0.8.0","0.8.2", "0.9.0", "0.9.3").distinct
@@ -70,10 +71,10 @@ trait RequestsTestModule extends TestModule.Utest {
   def forkArgs = Seq(
     "--add-opens", "java.net.http/jdk.internal.net.http=ALL-UNNAMED"
   )
-}
 
-object requests extends Module {
-  def goHttpBinVersion = "2.22.1"
+  def forkEnv = super.forkEnv() ++ Map(
+    "GO_HTTPBIN_EXE" -> httpbinArtifact().path.toString()
+  )
 
   def httpbinArtifact = Task {
     val destDir = Task.dest
@@ -99,11 +100,13 @@ object requests extends Module {
           case other => sys.error(s"Unsupported architecture: ${other}")
     val ext = if (Properties.isWin) "zip" else "tar.gz"
     val prefix = s"https://github.com/mccutchen/go-httpbin/releases/download/v${goHttpBinVersion}"
-    val checksumUrl = s"${prefix}/checksums.txt"
+
     val archiveName = s"go-httpbin-${platfrom}-${arch}.${ext}"
     val archiveUrl = s"${prefix}/${archiveName}"
+    val archiveChecksumUrl = s"${prefix}/checksums.txt"
     val archivePath = destDir / s"go-httpbin.${ext}"
-    val checksum = req.get(checksumUrl).lines()
+
+    val checksum = req.get(archiveChecksumUrl).lines()
       .find(_.endsWith(archiveName))
       .flatMap(_.split(" ").headOption)
       .getOrElse(sys.error(s"Could not find checksum for ${archiveName}"))
@@ -128,14 +131,12 @@ object requests extends Module {
       sys.error(s"Expected to find executable `go-httpbin` in ${destDir}, but it was not.")
     PathRef(targetExecBin)
   }
+}
 
+object requests extends Module {
   object jvm extends Cross[RequestsJvmModule](scalaVersions)
   trait RequestsJvmModule extends RequestsCrossScalaModule {
-    object test extends ScalaTests with RequestsTestModule {
-      def forkEnv = super.forkEnv() ++ Map(
-        "GO_HTTPBIN_EXE" -> httpbinArtifact().path.toString()
-      )
-    }
+    object test extends ScalaTests with RequestsTestModul
   }
 
   // // Scala Native is only supported for Scala 3

--- a/build.mill
+++ b/build.mill
@@ -138,16 +138,16 @@ object requests extends Module {
     }
   }
 
-  // Scala Native is only supported for Scala 3
-  object native extends Cross[RequestsNativeModule](scala3Versions)
-  trait RequestsNativeModule extends RequestsCrossScalaModule with ScalaNativeModule {
-    override def scalaNativeVersion = scalaNativeVer
+  // // Scala Native is only supported for Scala 3
+  // object native extends Cross[RequestsNativeModule](scala3Versions)
+  // trait RequestsNativeModule extends RequestsCrossScalaModule with ScalaNativeModule {
+  //   override def scalaNativeVersion = scalaNativeVer
 
-    def mvnDeps = super.mvnDeps() ++ Seq(
-      mvn"com.github.lolgab::scala-native-crypto::0.0.0-64-255fa4-DIRTY5a4581dc",
-      mvn"io.lqhuang::scala-native-java-http-client::0.0.0-251-fd6fcc-DIRTY79dbd950",
-    )
+  //   def mvnDeps = super.mvnDeps() ++ Seq(
+  //     mvn"com.github.lolgab::scala-native-crypto::0.0.0-64-255fa4-DIRTY5a4581dc",
+  //     mvn"io.lqhuang::scala-native-java-http-client::0.0.0-251-fd6fcc-DIRTY79dbd950",
+  //   )
 
-    object test extends ScalaNativeTests with RequestsTestModule
-  }
+  //   object test extends ScalaNativeTests with RequestsTestModule
+  // }
 }

--- a/build.mill
+++ b/build.mill
@@ -64,7 +64,7 @@ trait RequestsTestModule extends TestModule.Utest {
   def mvnDeps = Seq(
     mvn"com.lihaoyi::utest::0.9.5",
     mvn"com.lihaoyi::ujson::4.4.3",
-    mvn"com.lihaoyi::os-lib:0.11.8",
+    mvn"com.lihaoyi::os-lib::0.11.8",
   )
 
   def forkArgs = Seq(

--- a/build.mill
+++ b/build.mill
@@ -21,12 +21,12 @@ import com.github.lolgab.mill.mima._
 
 val communityBuildDottyVersion = sys.props.get("dottyVersion").toList
 val scalaNextVersion = sys.props.get("scalaNextVersion").toList
-val scalaVersions = List("2.12.20", "2.13.15", "3.3.4") ++ scalaNextVersion ++ communityBuildDottyVersion
+val scalaVersions = List("2.12.20", "2.13.15", "3.3.7") ++ scalaNextVersion ++ communityBuildDottyVersion
 val scala3Versions = scalaVersions.filter(_.startsWith("3"))
 val scalaNativeVer = "0.5.10"
 
 trait MimaCheck extends Mima {
-  def mimaPreviousVersions = Seq("0.6.9", "0.7.0", "0.7.1", "0.8.0","0.8.2", "0.9.0").distinct
+  def mimaPreviousVersions = Seq("0.6.9", "0.7.0", "0.7.1", "0.8.0","0.8.2", "0.9.0", "0.9.3").distinct
 
   override def mimaBinaryIssueFilters = Seq(
     ProblemFilter.exclude[ReversedMissingMethodProblem]("requests.BaseSession.send"),

--- a/build.mill
+++ b/build.mill
@@ -1,5 +1,5 @@
-//| mill-version: 1.1.5
-//| mill-jvm-version: 17
+//| mill-version: 1.1.6
+//| mill-jvm-version: 25
 //| mvnDeps:
 //| - com.github.lolgab::mill-mima_mill1:0.2.1
 package build
@@ -133,18 +133,21 @@ object requests extends Module {
   trait RequestsJvmModule extends RequestsCrossScalaModule {
     object test extends ScalaTests with RequestsTestModule {
       def forkEnv = super.forkEnv() ++ Map(
-          "GO_HTTPBIN_EXE" -> httpbinArtifact().path.toString
+        "GO_HTTPBIN_EXE" -> httpbinArtifact().path.toString()
       )
     }
   }
 
-  // // Scala Native is only supported for Scala 3
-  // object native extends Cross[RequestsNativeModule](scala3Versions)
-  // trait RequestsNativeModule extends RequestsCrossScalaModule with ScalaNativeModule {
-  //   override def scalaNativeVersion = scalaNativeVer
+  // Scala Native is only supported for Scala 3
+  object native extends Cross[RequestsNativeModule](scala3Versions)
+  trait RequestsNativeModule extends RequestsCrossScalaModule with ScalaNativeModule {
+    override def scalaNativeVersion = scalaNativeVer
 
-  //   def mvnDeps = super.mvnDeps() ++ Seq(mvn"com.github.lolgab::scala-native-crypto::0.3.0")
+    def mvnDeps = super.mvnDeps() ++ Seq(
+      mvn"com.github.lolgab::scala-native-crypto::0.0.0-64-255fa4-DIRTY5a4581dc",
+      mvn"io.lqhuang::scala-native-java-http-client::0.0.0-251-fd6fcc-DIRTY79dbd950",
+    )
 
-  //   object test extends ScalaNativeTests with RequestsTestModule
-  // }
+    object test extends ScalaNativeTests with RequestsTestModule
+  }
 }

--- a/build.mill
+++ b/build.mill
@@ -15,10 +15,11 @@ import com.github.lolgab.mill.mima._
 val communityBuildDottyVersion = sys.props.get("dottyVersion").toList
 val scalaNextVersion = sys.props.get("scalaNextVersion")
 val scalaVersions = List("2.12.20", "2.13.15", "3.3.4") ++ scalaNextVersion ++ communityBuildDottyVersion
-val scalaNativeVer = "0.5.6"
+val scala3Versions = scalaVersions.filter(_.startsWith("3"))
+val scalaNativeVer = "0.5.10"
 
 trait MimaCheck extends Mima {
-   def mimaPreviousVersions = Seq("0.6.9", "0.7.0", "0.7.1", "0.8.0","0.8.2", "0.9.0").distinct
+  def mimaPreviousVersions = Seq("0.6.9", "0.7.0", "0.7.1", "0.8.0","0.8.2", "0.9.0").distinct
 
   override def mimaBinaryIssueFilters = Seq(
     ProblemFilter.exclude[ReversedMissingMethodProblem]("requests.BaseSession.send"),
@@ -45,35 +46,38 @@ trait RequestsPublishModule extends PublishModule with MimaCheck {
   def mvnDeps = Seq(mvn"com.lihaoyi::geny::1.1.1")
 }
 
-trait RequestsCrossScalaModule extends CrossScalaModule with ScalaModule {
+trait RequestsCrossScalaModule
+  extends CrossScalaModule with ScalaModule with RequestsPublishModule {
   def moduleDir = build.moduleDir / "requests"
+
   def sources = Task.Sources("src")
 }
 
 trait RequestsTestModule extends TestModule.Utest {
   def mvnDeps = Seq(
-    mvn"com.lihaoyi::utest::0.7.10",
-    mvn"com.lihaoyi::ujson::1.3.13",
-    mvn"com.dimafeng::testcontainers-scala-core:0.43.0"
+    mvn"com.lihaoyi::utest::0.9.5",
+    mvn"com.lihaoyi::ujson::4.4.3",
+    mvn"com.dimafeng::testcontainers-scala-core:0.44.1"
   )
+
   def forkArgs = Seq(
     "--add-opens", "java.net.http/jdk.internal.net.http=ALL-UNNAMED"
   )
 }
 
 object requests extends Module {
-  trait RequestsJvmModule extends RequestsCrossScalaModule with RequestsPublishModule {
+  object jvm extends Cross[RequestsJvmModule](scalaVersions)
+  trait RequestsJvmModule extends RequestsCrossScalaModule {
     object test extends ScalaTests with RequestsTestModule
   }
-  object jvm extends Cross[RequestsJvmModule](scalaVersions)
 
-  // trait RequestsNativeModule extends ScalaNativeModule with RequestsPublishModule {
+  // // Scala Native is only supported for Scala 3
+  // object native extends Cross[RequestsNativeModule](scala3Versions)
+  // trait RequestsNativeModule extends RequestsCrossScalaModule with ScalaNativeModule {
   //   override def scalaNativeVersion = scalaNativeVer
-  //
-  //   def mvnDeps =
-  //     super.mvnDeps() ++ Seq(mvn"com.github.lolgab::scala-native-crypto::0.1.0")
-  //
+
+  //   def mvnDeps = super.mvnDeps() ++ Seq(mvn"com.github.lolgab::scala-native-crypto::0.3.0")
+
   //   object test extends ScalaNativeTests with RequestsTestModule
   // }
-  // object native extends Cross[RequestsNativeModule](scalaVersions)
 }

--- a/build.mill
+++ b/build.mill
@@ -4,6 +4,13 @@
 //| - com.github.lolgab::mill-mima_mill1:0.2.0
 package build
 
+import java.io.FileOutputStream
+import java.math.BigInteger
+import java.security.MessageDigest
+
+import scala.util.Properties
+import _root_.{requests as req}
+
 import mill._
 import scalalib._
 import scalanativelib._
@@ -57,7 +64,7 @@ trait RequestsTestModule extends TestModule.Utest {
   def mvnDeps = Seq(
     mvn"com.lihaoyi::utest::0.9.5",
     mvn"com.lihaoyi::ujson::4.4.3",
-    mvn"com.dimafeng::testcontainers-scala-core:0.44.1"
+    mvn"com.lihaoyi::os-lib:0.11.8",
   )
 
   def forkArgs = Seq(
@@ -66,9 +73,66 @@ trait RequestsTestModule extends TestModule.Utest {
 }
 
 object requests extends Module {
+  def goHttpBinVersion = "2.22.1"
+
+  def httpbinArtifact = Task {
+    val destDir = Task.dest
+    def calcChecksum(path: os.Path): String = {
+      val digest = MessageDigest.getInstance("SHA-256")
+      val hash = digest.digest(path.getInputStream.readAllBytes())
+      new BigInteger(1, hash).toString(16)
+    }
+
+    val platfrom =
+      if Properties.isLinux then "linux"
+      else if Properties.isWin then "windows"
+      else if Properties.isMac then "darwin"
+      else sys.error(s"Unsupported platform ${Properties.osName}")
+    val arch =
+      if Properties.isMac
+      then
+        "all"
+      else
+        System.getProperty("os.arch") match
+          case "aarch64" => "arm64"
+          case "x86_64" => "amd64"
+          case "amd64" => "amd64"
+          case other => sys.error(s"Unsupported architecture: ${other}")
+    val prefix = s"https://github.com/mccutchen/go-httpbin/releases/download/v${goHttpBinVersion}"
+    val checksumUrl = s"${prefix}/checksums.txt"
+    val archiveName = s"go-httpbin-${platfrom}-${arch}.tar.gz"
+    val archiveUrl = s"${prefix}/${archiveName}"
+    val archivePath = destDir / "go-httpbin.tar.gz"
+    val checksum = req.get(checksumUrl).lines()
+      .find(_.endsWith(archiveName))
+      .flatMap(_.split(" ").headOption)
+      .getOrElse(sys.error(s"Could not find checksum for ${archiveName}"))
+
+    val isDownload =
+      if !os.exists(archivePath)
+      then true
+      else calcChecksum(archivePath) != checksum
+    if (isDownload) {
+      req.get.stream(archiveUrl).writeBytesTo(new FileOutputStream(archivePath.toString))
+      val localChecksum = calcChecksum(archivePath)
+      if (localChecksum != checksum)
+        sys.error(s"Checksum (${localChecksum}) of downloaded archive (${archiveUrl}) does not match expected ${checksum}")
+    }
+    os.proc("tar", "xzf", archivePath, "-C", destDir).call()
+
+    val targetExecBin = destDir / "go-httpbin"
+    if (!os.exists(targetExecBin) || !os.isExecutable(targetExecBin))
+      sys.error(s"Expected to find executable `go-httpbin` in ${destDir}, but it was not.")
+    PathRef(targetExecBin)
+  }
+
   object jvm extends Cross[RequestsJvmModule](scalaVersions)
   trait RequestsJvmModule extends RequestsCrossScalaModule {
-    object test extends ScalaTests with RequestsTestModule
+    object test extends ScalaTests with RequestsTestModule {
+      def forkEnv = super.forkEnv() ++ Map(
+          "GO_HTTPBIN_EXE" -> httpbinArtifact().path.toString
+      )
+    }
   }
 
   // // Scala Native is only supported for Scala 3

--- a/build.mill
+++ b/build.mill
@@ -1,4 +1,4 @@
-//| mill-version: 1.1.0-RC1
+//| mill-version: 1.1.5
 //| mill-jvm-version: 11
 //| mvnDeps:
 //| - com.github.lolgab::mill-mima_mill1:0.2.0
@@ -20,7 +20,7 @@ import mill.util.VcsVersion
 import com.github.lolgab.mill.mima._
 
 val communityBuildDottyVersion = sys.props.get("dottyVersion").toList
-val scalaNextVersion = sys.props.get("scalaNextVersion")
+val scalaNextVersion = sys.props.get("scalaNextVersion").toList
 val scalaVersions = List("2.12.20", "2.13.15", "3.3.4") ++ scalaNextVersion ++ communityBuildDottyVersion
 val scala3Versions = scalaVersions.filter(_.startsWith("3"))
 val scalaNativeVer = "0.5.10"

--- a/mill
+++ b/mill
@@ -2,7 +2,7 @@
 
 set -e
 
-if [ -z "${DEFAULT_MILL_VERSION}" ] ; then DEFAULT_MILL_VERSION="1.1.5-21-53d1ba"; fi
+if [ -z "${DEFAULT_MILL_VERSION}" ] ; then DEFAULT_MILL_VERSION="1.1.6"; fi
 
 if [ -z "${GITHUB_RELEASE_CDN}" ] ; then GITHUB_RELEASE_CDN=""; fi
 

--- a/mill
+++ b/mill
@@ -1,57 +1,14 @@
 #!/usr/bin/env sh
 
-# This is a wrapper script, that automatically selects or downloads Mill from Maven Central or GitHub release pages.
-#
-# This script determines the Mill version to use by trying these sources
-#   - env-variable `MILL_VERSION`
-#   - local file `.mill-version`
-#   - local file `.config/mill-version`
-#   - `mill-version` from YAML fronmatter of current buildfile
-#   - if accessible, find the latest stable version available on Maven Central (https://repo1.maven.org/maven2)
-#   - env-variable `DEFAULT_MILL_VERSION`
-#
-# If a version has the suffix '-native' a native binary will be used.
-# If a version has the suffix '-jvm' an executable jar file will be used, requiring an already installed Java runtime.
-# If no such suffix is found, the script will pick a default based on version and platform.
-#
-# Once a version was determined, it tries to use either
-#    - a system-installed mill, if found and it's version matches
-#    - an already downloaded version under ~/.cache/mill/download
-#
-# If no working mill version was found on the system,
-# this script downloads a binary file from Maven Central or Github Pages (this is version dependent)
-# into a cache location (~/.cache/mill/download).
-#
-# Mill Project URL: https://github.com/com-lihaoyi/mill
-# Script Version: 1.0.0-M1-21-7b6fae-DIRTY892b63e8
-#
-# If you want to improve this script, please also contribute your changes back!
-# This script was generated from: dist/scripts/src/mill.sh
-#
-# Licensed under the Apache License, Version 2.0
-
 set -e
 
-if [ -z "${DEFAULT_MILL_VERSION}" ] ; then
-  DEFAULT_MILL_VERSION=1.0.0-RC1
-fi
+if [ -z "${DEFAULT_MILL_VERSION}" ] ; then DEFAULT_MILL_VERSION="1.1.5-21-53d1ba"; fi
 
+if [ -z "${GITHUB_RELEASE_CDN}" ] ; then GITHUB_RELEASE_CDN=""; fi
 
-if [ -z "${GITHUB_RELEASE_CDN}" ] ; then
-  GITHUB_RELEASE_CDN=""
-fi
-
+if [ -z "$MILL_MAIN_CLI" ] ; then MILL_MAIN_CLI="${0}"; fi
 
 MILL_REPO_URL="https://github.com/com-lihaoyi/mill"
-
-if [ -z "${CURL_CMD}" ] ; then
-  CURL_CMD=curl
-fi
-
-# Explicit commandline argument takes precedence over all other methods
-if [ "$1" = "--mill-version" ] ; then
-    echo "The --mill-version option is no longer supported." 1>&2
-fi
 
 MILL_BUILD_SCRIPT=""
 
@@ -63,259 +20,174 @@ elif [ -f "build.sc" ] ; then
   MILL_BUILD_SCRIPT="build.sc"
 fi
 
-# Please note, that if a MILL_VERSION is already set in the environment,
-# We reuse it's value and skip searching for a value.
+# `s/.*://`:
+#   This is a greedy match that removes everything from the beginning of the line up to (and including) the last
+#   colon (:). This effectively isolates the value part of the declaration.
+#
+#  `s/#.*//`:
+#    This removes any comments at the end of the line.
+#
+#  `s/['\"]//g`:
+#    This removes all single and double quotes from the string, wherever they appear (g is for "global").
+#
+#  `s/^[[:space:]]*//; s/[[:space:]]*$//`:
+#    These two expressions trim any leading or trailing whitespace ([[:space:]] matches spaces and tabs).
+TRIM_VALUE_SED="s/.*://; s/#.*//; s/['\"]//g; s/^[[:space:]]*//; s/[[:space:]]*$//"
 
-# If not already set, read .mill-version file
 if [ -z "${MILL_VERSION}" ] ; then
   if [ -f ".mill-version" ] ; then
     MILL_VERSION="$(tr '\r' '\n' < .mill-version | head -n 1 2> /dev/null)"
   elif [ -f ".config/mill-version" ] ; then
     MILL_VERSION="$(tr '\r' '\n' < .config/mill-version | head -n 1 2> /dev/null)"
+  elif [ -f "build.mill.yaml" ] ; then
+    MILL_VERSION="$(grep -E "mill-version:" "build.mill.yaml" | sed -E "$TRIM_VALUE_SED")"
   elif [ -n "${MILL_BUILD_SCRIPT}" ] ; then
-    MILL_VERSION="$(cat ${MILL_BUILD_SCRIPT} | grep '//[|]  *mill-version:  *' | sed 's;//|  *mill-version:  *;;')"
+    MILL_VERSION="$(grep -E "//\|.*mill-version" "${MILL_BUILD_SCRIPT}" | sed -E "$TRIM_VALUE_SED")"
   fi
 fi
+
+if [ -z "${MILL_VERSION}" ] ; then MILL_VERSION="${DEFAULT_MILL_VERSION}"; fi
 
 MILL_USER_CACHE_DIR="${XDG_CACHE_HOME:-${HOME}/.cache}/mill"
 
-if [ -z "${MILL_DOWNLOAD_PATH}" ] ; then
-  MILL_DOWNLOAD_PATH="${MILL_USER_CACHE_DIR}/download"
-fi
-
-# If not already set, try to fetch newest from Github
-if [ -z "${MILL_VERSION}" ] ; then
-  # TODO: try to load latest version from release page
-  echo "No mill version specified." 1>&2
-  echo "You should provide a version via a '//| mill-version: ' comment or a '.mill-version' file." 1>&2
-
-  mkdir -p "${MILL_DOWNLOAD_PATH}"
-  LANG=C touch -d '1 hour ago' "${MILL_DOWNLOAD_PATH}/.expire_latest" 2>/dev/null || (
-    # we might be on OSX or BSD which don't have -d option for touch
-    # but probably a -A [-][[hh]mm]SS
-    touch "${MILL_DOWNLOAD_PATH}/.expire_latest"; touch -A -010000 "${MILL_DOWNLOAD_PATH}/.expire_latest"
-  ) || (
-    # in case we still failed, we retry the first touch command with the intention
-    # to show the (previously suppressed) error message
-    LANG=C touch -d '1 hour ago' "${MILL_DOWNLOAD_PATH}/.expire_latest"
-  )
-
-  # POSIX shell variant of bash's -nt operator, see https://unix.stackexchange.com/a/449744/6993
-  # if [ "${MILL_DOWNLOAD_PATH}/.latest" -nt "${MILL_DOWNLOAD_PATH}/.expire_latest" ] ; then
-  if [ -n "$(find -L "${MILL_DOWNLOAD_PATH}/.latest" -prune -newer "${MILL_DOWNLOAD_PATH}/.expire_latest")" ]; then
-    # we know a current latest version
-    MILL_VERSION=$(head -n 1 "${MILL_DOWNLOAD_PATH}"/.latest 2> /dev/null)
-  fi
-
-  if [ -z "${MILL_VERSION}" ] ; then
-    # we don't know a current latest version
-    echo "Retrieving latest mill version ..." 1>&2
-    LANG=C ${CURL_CMD} -s -i -f -I ${MILL_REPO_URL}/releases/latest 2> /dev/null  | grep --ignore-case Location: | sed s'/^.*tag\///' | tr -d '\r\n' > "${MILL_DOWNLOAD_PATH}/.latest"
-    MILL_VERSION=$(head -n 1 "${MILL_DOWNLOAD_PATH}"/.latest 2> /dev/null)
-  fi
-
-  if [ -z "${MILL_VERSION}" ] ; then
-    # Last resort
-    MILL_VERSION="${DEFAULT_MILL_VERSION}"
-    echo "Falling back to hardcoded mill version ${MILL_VERSION}" 1>&2
-  else
-    echo "Using mill version ${MILL_VERSION}" 1>&2
-  fi
-fi
+if [ -z "${MILL_FINAL_DOWNLOAD_FOLDER}" ] ; then MILL_FINAL_DOWNLOAD_FOLDER="${MILL_USER_CACHE_DIR}/download"; fi
 
 MILL_NATIVE_SUFFIX="-native"
 MILL_JVM_SUFFIX="-jvm"
-FULL_MILL_VERSION=$MILL_VERSION
 ARTIFACT_SUFFIX=""
-set_artifact_suffix(){
-  if [ "$(expr substr $(uname -s) 1 5 2>/dev/null)" = "Linux" ]; then
-    if [ "$(uname -m)" = "aarch64" ]; then
-      ARTIFACT_SUFFIX="-native-linux-aarch64"
-    else
-      ARTIFACT_SUFFIX="-native-linux-amd64"
-    fi
-  elif [ "$(uname)" = "Darwin" ]; then
-    if [ "$(uname -m)" = "arm64" ]; then
-      ARTIFACT_SUFFIX="-native-mac-aarch64"
-    else
-      ARTIFACT_SUFFIX="-native-mac-amd64"
-    fi
+
+# Check if GLIBC version is at least the required version
+# Returns 0 (true) if GLIBC >= required version, 1 (false) otherwise
+check_glibc_version() {
+  required_version="2.39"
+  required_major=$(echo "$required_version" | cut -d. -f1)
+  required_minor=$(echo "$required_version" | cut -d. -f2)
+  # Get GLIBC version from ldd --version (first line contains version like "ldd (GNU libc) 2.31")
+  glibc_version=$(ldd --version 2>/dev/null | head -n 1 | grep -oE '[0-9]+\.[0-9]+$' || echo "")
+  if [ -z "$glibc_version" ]; then
+    # If we can't determine GLIBC version, assume it's too old
+    return 1
+  fi
+  glibc_major=$(echo "$glibc_version" | cut -d. -f1)
+  glibc_minor=$(echo "$glibc_version" | cut -d. -f2)
+  if [ "$glibc_major" -gt "$required_major" ]; then
+    return 0
+  elif [ "$glibc_major" -eq "$required_major" ] && [ "$glibc_minor" -ge "$required_minor" ]; then
+    return 0
   else
-     echo "This native mill launcher supports only Linux and macOS." 1>&2
-     exit 1
+    return 1
+  fi
+}
+
+set_artifact_suffix() {
+  if [ "$(uname -s 2>/dev/null | cut -c 1-5)" = "Linux" ]; then
+    # Native binaries require new enough GLIBC; fall back to JVM launcher if older
+    if ! check_glibc_version; then
+      return
+    fi
+    if [ "$(uname -m)" = "aarch64" ]; then ARTIFACT_SUFFIX="-native-linux-aarch64"
+    else ARTIFACT_SUFFIX="-native-linux-amd64"; fi
+  elif [ "$(uname)" = "Darwin" ]; then
+    if [ "$(uname -m)" = "arm64" ]; then ARTIFACT_SUFFIX="-native-mac-aarch64"
+    else ARTIFACT_SUFFIX="-native-mac-amd64"; fi
+  else
+    echo "This native mill launcher supports only Linux and macOS." 1>&2
+    exit 1
   fi
 }
 
 case "$MILL_VERSION" in
-    *"$MILL_NATIVE_SUFFIX")
-  MILL_VERSION=${MILL_VERSION%"$MILL_NATIVE_SUFFIX"}
-  set_artifact_suffix
-  ;;
+  *"$MILL_NATIVE_SUFFIX")
+    MILL_VERSION=${MILL_VERSION%"$MILL_NATIVE_SUFFIX"}
+    set_artifact_suffix
+    ;;
 
-    *"$MILL_JVM_SUFFIX")
+  *"$MILL_JVM_SUFFIX")
     MILL_VERSION=${MILL_VERSION%"$MILL_JVM_SUFFIX"}
-  ;;
+    ;;
 
-    *)
-  case "$MILL_VERSION" in
-    0.1.*) ;;
-    0.2.*) ;;
-    0.3.*) ;;
-    0.4.*) ;;
-    0.5.*) ;;
-    0.6.*) ;;
-    0.7.*) ;;
-    0.8.*) ;;
-    0.9.*) ;;
-    0.10.*) ;;
-    0.11.*) ;;
-    0.12.*) ;;
-    *)
-      set_artifact_suffix
-  esac
-  ;;
+  *)
+    case "$MILL_VERSION" in
+      0.1.* | 0.2.* | 0.3.* | 0.4.* | 0.5.* | 0.6.* | 0.7.* | 0.8.* | 0.9.* | 0.10.* | 0.11.* | 0.12.*)
+        ;;
+      *)
+        set_artifact_suffix
+        ;;
+    esac
+    ;;
 esac
 
-MILL="${MILL_DOWNLOAD_PATH}/$MILL_VERSION$ARTIFACT_SUFFIX"
-
-try_to_use_system_mill() {
-  if [ "$(uname)" != "Linux" ]; then
-    return 0
-  fi
-
-  MILL_IN_PATH="$(command -v mill || true)"
-
-  if [ -z "${MILL_IN_PATH}" ]; then
-    return 0
-  fi
-
-  SYSTEM_MILL_FIRST_TWO_BYTES=$(head --bytes=2 "${MILL_IN_PATH}")
-  if [ "${SYSTEM_MILL_FIRST_TWO_BYTES}" = "#!" ]; then
-	  # MILL_IN_PATH is (very likely) a shell script and not the mill
-	  # executable, ignore it.
-	  return 0
-  fi
-
-  SYSTEM_MILL_PATH=$(readlink -e "${MILL_IN_PATH}")
-  SYSTEM_MILL_SIZE=$(stat --format=%s "${SYSTEM_MILL_PATH}")
-  SYSTEM_MILL_MTIME=$(stat --format=%y "${SYSTEM_MILL_PATH}")
-
-  if [ ! -d "${MILL_USER_CACHE_DIR}" ]; then
-    mkdir -p "${MILL_USER_CACHE_DIR}"
-  fi
-
-  SYSTEM_MILL_INFO_FILE="${MILL_USER_CACHE_DIR}/system-mill-info"
-  if [ -f "${SYSTEM_MILL_INFO_FILE}" ]; then
-    parseSystemMillInfo() {
-        LINE_NUMBER="${1}"
-        # Select the line number of the SYSTEM_MILL_INFO_FILE, cut the
-        # variable definition in that line in two halves and return
-        # the value, and finally remove the quotes.
-        sed -n "${LINE_NUMBER}p" "${SYSTEM_MILL_INFO_FILE}" |\
-            cut -d= -f2 |\
-            sed 's/"\(.*\)"/\1/'
-    }
-
-    CACHED_SYSTEM_MILL_PATH=$(parseSystemMillInfo 1)
-    CACHED_SYSTEM_MILL_VERSION=$(parseSystemMillInfo 2)
-    CACHED_SYSTEM_MILL_SIZE=$(parseSystemMillInfo 3)
-    CACHED_SYSTEM_MILL_MTIME=$(parseSystemMillInfo 4)
-
-    if [ "${SYSTEM_MILL_PATH}" = "${CACHED_SYSTEM_MILL_PATH}" ] \
-           && [ "${SYSTEM_MILL_SIZE}" = "${CACHED_SYSTEM_MILL_SIZE}" ] \
-           && [ "${SYSTEM_MILL_MTIME}" = "${CACHED_SYSTEM_MILL_MTIME}" ]; then
-      if [ "${CACHED_SYSTEM_MILL_VERSION}" = "${MILL_VERSION}" ]; then
-          MILL="${SYSTEM_MILL_PATH}"
-          return 0
-      else
-          return 0
-      fi
-    fi
-  fi
-
-  SYSTEM_MILL_VERSION=$(${SYSTEM_MILL_PATH} --version | head -n1 | sed -n 's/^Mill.*version \(.*\)/\1/p')
-
-  cat <<EOF > "${SYSTEM_MILL_INFO_FILE}"
-CACHED_SYSTEM_MILL_PATH="${SYSTEM_MILL_PATH}"
-CACHED_SYSTEM_MILL_VERSION="${SYSTEM_MILL_VERSION}"
-CACHED_SYSTEM_MILL_SIZE="${SYSTEM_MILL_SIZE}"
-CACHED_SYSTEM_MILL_MTIME="${SYSTEM_MILL_MTIME}"
-EOF
-
-  if [ "${SYSTEM_MILL_VERSION}" = "${MILL_VERSION}" ]; then
-    MILL="${SYSTEM_MILL_PATH}"
-  fi
-}
-try_to_use_system_mill
+MILL="${MILL_FINAL_DOWNLOAD_FOLDER}/$MILL_VERSION$ARTIFACT_SUFFIX"
 
 # If not already downloaded, download it
 if [ ! -s "${MILL}" ] || [ "$MILL_TEST_DRY_RUN_LAUNCHER_SCRIPT" = "1" ] ; then
   case $MILL_VERSION in
-    0.0.* | 0.1.* | 0.2.* | 0.3.* | 0.4.* )
-      DOWNLOAD_SUFFIX=""
-      DOWNLOAD_FROM_MAVEN=0
+    0.0.* | 0.1.* | 0.2.* | 0.3.* | 0.4.*)
+      MILL_DOWNLOAD_SUFFIX=""
+      MILL_DOWNLOAD_FROM_MAVEN=0
       ;;
-    0.5.* | 0.6.* | 0.7.* | 0.8.* | 0.9.* | 0.10.* | 0.11.0-M* )
-      DOWNLOAD_SUFFIX="-assembly"
-      DOWNLOAD_FROM_MAVEN=0
+    0.5.* | 0.6.* | 0.7.* | 0.8.* | 0.9.* | 0.10.* | 0.11.0-M*)
+      MILL_DOWNLOAD_SUFFIX="-assembly"
+      MILL_DOWNLOAD_FROM_MAVEN=0
       ;;
     *)
-      DOWNLOAD_SUFFIX="-assembly"
-      DOWNLOAD_FROM_MAVEN=1
+      MILL_DOWNLOAD_SUFFIX="-assembly"
+      MILL_DOWNLOAD_FROM_MAVEN=1
       ;;
   esac
   case $MILL_VERSION in
-    0.12.0 | 0.12.1 | 0.12.2 | 0.12.3 | 0.12.4 | 0.12.5 | 0.12.6 | 0.12.7 | 0.12.8 | 0.12.9 | 0.12.10 | 0.12.11 )
-      DOWNLOAD_EXT="jar"
+    0.12.0 | 0.12.1 | 0.12.2 | 0.12.3 | 0.12.4 | 0.12.5 | 0.12.6 | 0.12.7 | 0.12.8 | 0.12.9 | 0.12.10 | 0.12.11)
+      MILL_DOWNLOAD_EXT="jar"
       ;;
-    0.12.* )
-      DOWNLOAD_EXT="exe"
+    0.12.*)
+      MILL_DOWNLOAD_EXT="exe"
       ;;
-    0.* )
-      DOWNLOAD_EXT="jar"
+    0.*)
+      MILL_DOWNLOAD_EXT="jar"
       ;;
     *)
-      DOWNLOAD_EXT="exe"
+      MILL_DOWNLOAD_EXT="exe"
       ;;
   esac
 
-  DOWNLOAD_FILE=$(mktemp mill.XXXXXX)
-  if [ "$DOWNLOAD_FROM_MAVEN" = "1" ] ; then
-    DOWNLOAD_URL="https://repo1.maven.org/maven2/com/lihaoyi/mill-dist${ARTIFACT_SUFFIX}/${MILL_VERSION}/mill-dist${ARTIFACT_SUFFIX}-${MILL_VERSION}.${DOWNLOAD_EXT}"
+  MILL_TEMP_DOWNLOAD_FILE="${MILL_OUTPUT_DIR:-out}/mill-temp-download"
+  mkdir -p "$(dirname "${MILL_TEMP_DOWNLOAD_FILE}")"
+
+  if [ "$MILL_DOWNLOAD_FROM_MAVEN" = "1" ] ; then
+    MILL_DOWNLOAD_URL="https://repo1.maven.org/maven2/com/lihaoyi/mill-dist${ARTIFACT_SUFFIX}/${MILL_VERSION}/mill-dist${ARTIFACT_SUFFIX}-${MILL_VERSION}.${MILL_DOWNLOAD_EXT}"
   else
     MILL_VERSION_TAG=$(echo "$MILL_VERSION" | sed -E 's/([^-]+)(-M[0-9]+)?(-.*)?/\1\2/')
-    DOWNLOAD_URL="${GITHUB_RELEASE_CDN}${MILL_REPO_URL}/releases/download/${MILL_VERSION_TAG}/${MILL_VERSION}${DOWNLOAD_SUFFIX}"
+    MILL_DOWNLOAD_URL="${GITHUB_RELEASE_CDN}${MILL_REPO_URL}/releases/download/${MILL_VERSION_TAG}/${MILL_VERSION}${MILL_DOWNLOAD_SUFFIX}"
     unset MILL_VERSION_TAG
   fi
 
+
   if [ "$MILL_TEST_DRY_RUN_LAUNCHER_SCRIPT" = "1" ] ; then
-    echo $DOWNLOAD_URL
-    echo $MILL
+    echo "$MILL_DOWNLOAD_URL"
+    echo "$MILL"
     exit 0
   fi
-  # TODO: handle command not found
-  echo "Downloading mill ${MILL_VERSION} from ${DOWNLOAD_URL} ..." 1>&2
-  ${CURL_CMD} -f -L -o "${DOWNLOAD_FILE}" "${DOWNLOAD_URL}"
-  chmod +x "${DOWNLOAD_FILE}"
-  mkdir -p "${MILL_DOWNLOAD_PATH}"
-  mv "${DOWNLOAD_FILE}" "${MILL}"
 
-  unset DOWNLOAD_FILE
-  unset DOWNLOAD_SUFFIX
-fi
+  echo "Downloading mill ${MILL_VERSION} from ${MILL_DOWNLOAD_URL} ..." 1>&2
+  curl -f -L -o "${MILL_TEMP_DOWNLOAD_FILE}" "${MILL_DOWNLOAD_URL}"
 
-if [ -z "$MILL_MAIN_CLI" ] ; then
-  MILL_MAIN_CLI="${0}"
+  chmod +x "${MILL_TEMP_DOWNLOAD_FILE}"
+
+  mkdir -p "${MILL_FINAL_DOWNLOAD_FOLDER}"
+  mv "${MILL_TEMP_DOWNLOAD_FILE}" "${MILL}"
+
+  unset MILL_TEMP_DOWNLOAD_FILE
+  unset MILL_DOWNLOAD_SUFFIX
 fi
 
 MILL_FIRST_ARG=""
-if [ "$1" = "--bsp" ] || [ "$1" = "-i" ] || [ "$1" = "--interactive" ] || [ "$1" = "--no-server" ] || [ "$1" = "--no-daemon" ] || [ "$1" = "--repl" ] || [ "$1" = "--help" ] ; then
+if [ "$1" = "--bsp" ] || [ "${1#"-i"}" != "$1" ] || [ "$1" = "--interactive" ] || [ "$1" = "--no-server" ] || [ "$1" = "--no-daemon" ] || [ "$1" = "--help" ] ; then
   # Need to preserve the first position of those listed options
   MILL_FIRST_ARG=$1
   shift
 fi
 
-unset MILL_DOWNLOAD_PATH
+unset MILL_FINAL_DOWNLOAD_FOLDER
 unset MILL_OLD_DOWNLOAD_PATH
 unset OLD_MILL
 unset MILL_VERSION

--- a/mill.bat
+++ b/mill.bat
@@ -1,0 +1,296 @@
+@echo off
+
+setlocal enabledelayedexpansion
+
+if [!DEFAULT_MILL_VERSION!]==[] ( set "DEFAULT_MILL_VERSION=1.1.5-21-53d1ba" )
+
+if [!MILL_GITHUB_RELEASE_CDN!]==[] ( set "MILL_GITHUB_RELEASE_CDN=" )
+
+if [!MILL_MAIN_CLI!]==[] ( set "MILL_MAIN_CLI=%~f0" )
+
+set "MILL_REPO_URL=https://github.com/com-lihaoyi/mill"
+
+SET MILL_BUILD_SCRIPT=
+
+if exist "build.mill" (
+  set MILL_BUILD_SCRIPT=build.mill
+) else (
+    if exist "build.mill.scala" (
+      set MILL_BUILD_SCRIPT=build.mill.scala
+    ) else (
+        if exist "build.sc" (
+          set MILL_BUILD_SCRIPT=build.sc
+        ) else (
+            rem no-op
+        )
+    )
+)
+
+if [!MILL_VERSION!]==[] (
+  if exist .mill-version (
+    set /p MILL_VERSION=<.mill-version
+  ) else (
+    if exist .config\mill-version (
+      set /p MILL_VERSION=<.config\mill-version
+    ) else (
+      rem Determine which config file to use for version extraction
+      set "MILL_VERSION_CONFIG_FILE="
+      set "MILL_VERSION_SEARCH_PATTERN="
+
+      if exist build.mill.yaml (
+        set "MILL_VERSION_CONFIG_FILE=build.mill.yaml"
+        set "MILL_VERSION_SEARCH_PATTERN=mill-version:"
+      ) else (
+        if not "%MILL_BUILD_SCRIPT%"=="" (
+          set "MILL_VERSION_CONFIG_FILE=%MILL_BUILD_SCRIPT%"
+          set "MILL_VERSION_SEARCH_PATTERN=//\|.*mill-version"
+        )
+      )
+
+      rem Process the config file if found
+      if not "!MILL_VERSION_CONFIG_FILE!"=="" (
+        rem Find the line and process it
+        for /f "tokens=*" %%a in ('findstr /R /C:"!MILL_VERSION_SEARCH_PATTERN!" "!MILL_VERSION_CONFIG_FILE!"') do (
+            set "line=%%a"
+
+            rem --- 1. Replicate sed 's/.*://' ---
+            rem This removes everything up to and including the first colon
+            set "line=!line:*:=!"
+
+            rem --- 2. Replicate sed 's/#.*//' ---
+            rem Split on '#' and keep the first part
+            for /f "tokens=1 delims=#" %%b in ("!line!") do (
+                set "line=%%b"
+            )
+
+            rem --- 3. Replicate sed 's/['"]//g' ---
+            rem Remove all quotes
+            set "line=!line:'=!"
+            set "line=!line:"=!"
+
+            rem --- 4. Replicate sed's trim/space removal ---
+            rem Remove all space characters from the result. This is more robust.
+            set "MILL_VERSION=!line: =!"
+
+            rem We found the version, so we can exit the loop
+            goto :version_found
+        )
+
+        :version_found
+        rem no-op
+      )
+    )
+  )
+)
+
+if [!MILL_VERSION!]==[] (
+    set MILL_VERSION=%DEFAULT_MILL_VERSION%
+)
+
+if [!MILL_FINAL_DOWNLOAD_FOLDER!]==[] set MILL_FINAL_DOWNLOAD_FOLDER=%USERPROFILE%\.cache\mill\download
+
+rem without bat file extension, cmd doesn't seem to be able to run it
+
+set "MILL_NATIVE_SUFFIX=-native"
+set "MILL_JVM_SUFFIX=-jvm"
+set "MILL_FULL_VERSION=%MILL_VERSION%"
+set "MILL_DOWNLOAD_EXT=.bat"
+set "ARTIFACT_SUFFIX="
+REM Check if MILL_VERSION contains MILL_NATIVE_SUFFIX
+echo !MILL_VERSION! | findstr /C:"%MILL_NATIVE_SUFFIX%" >nul
+if !errorlevel! equ 0 (
+    set "MILL_VERSION=%MILL_VERSION:-native=%"
+    REM -native images compiled with graal do not support windows-arm
+    REM https://github.com/oracle/graal/issues/9215
+    IF /I NOT "%PROCESSOR_ARCHITECTURE%"=="ARM64" (
+        set "ARTIFACT_SUFFIX=-native-windows-amd64"
+        set "MILL_DOWNLOAD_EXT=.exe"
+    ) else (
+        rem no-op
+    )
+) else (
+    echo !MILL_VERSION! | findstr /C:"%MILL_JVM_SUFFIX%" >nul
+    if !errorlevel! equ 0 (
+        set "MILL_VERSION=%MILL_VERSION:-jvm=%"
+    ) else (
+        set "SKIP_VERSION=false"
+        set "MILL_PREFIX=%MILL_VERSION:~0,4%"
+        if "!MILL_PREFIX!"=="0.1." set "SKIP_VERSION=true"
+        if "!MILL_PREFIX!"=="0.2." set "SKIP_VERSION=true"
+        if "!MILL_PREFIX!"=="0.3." set "SKIP_VERSION=true"
+        if "!MILL_PREFIX!"=="0.4." set "SKIP_VERSION=true"
+        if "!MILL_PREFIX!"=="0.5." set "SKIP_VERSION=true"
+        if "!MILL_PREFIX!"=="0.6." set "SKIP_VERSION=true"
+        if "!MILL_PREFIX!"=="0.7." set "SKIP_VERSION=true"
+        if "!MILL_PREFIX!"=="0.8." set "SKIP_VERSION=true"
+        if "!MILL_PREFIX!"=="0.9." set "SKIP_VERSION=true"
+        set "MILL_PREFIX=%MILL_VERSION:~0,5%"
+        if "!MILL_PREFIX!"=="0.10." set "SKIP_VERSION=true"
+        if "!MILL_PREFIX!"=="0.11." set "SKIP_VERSION=true"
+        if "!MILL_PREFIX!"=="0.12." set "SKIP_VERSION=true"
+
+        if "!SKIP_VERSION!"=="false" (
+            IF /I NOT "%PROCESSOR_ARCHITECTURE%"=="ARM64" (
+                set "ARTIFACT_SUFFIX=-native-windows-amd64"
+                set "MILL_DOWNLOAD_EXT=.exe"
+            )
+        ) else (
+            rem no-op
+        )
+    )
+)
+
+set MILL=%MILL_FINAL_DOWNLOAD_FOLDER%\!MILL_FULL_VERSION!!MILL_DOWNLOAD_EXT!
+
+set MILL_RESOLVE_DOWNLOAD=
+
+if not exist "%MILL%" (
+  set MILL_RESOLVE_DOWNLOAD=true
+) else (
+    if defined MILL_TEST_DRY_RUN_LAUNCHER_SCRIPT (
+        set MILL_RESOLVE_DOWNLOAD=true
+    ) else (
+        rem no-op
+    )
+)
+
+
+if [!MILL_RESOLVE_DOWNLOAD!]==[true] (
+    set MILL_VERSION_PREFIX=%MILL_VERSION:~0,4%
+    set MILL_SHORT_VERSION_PREFIX=%MILL_VERSION:~0,2%
+    rem Since 0.5.0
+    set MILL_DOWNLOAD_SUFFIX=-assembly
+    rem Since 0.11.0
+    set MILL_DOWNLOAD_FROM_MAVEN=1
+    if [!MILL_VERSION_PREFIX!]==[0.0.] (
+        set MILL_DOWNLOAD_SUFFIX=
+        set MILL_DOWNLOAD_FROM_MAVEN=0
+    )
+    if [!MILL_VERSION_PREFIX!]==[0.1.] (
+        set MILL_DOWNLOAD_SUFFIX=
+        set MILL_DOWNLOAD_FROM_MAVEN=0
+    )
+    if [!MILL_VERSION_PREFIX!]==[0.2.] (
+        set MILL_DOWNLOAD_SUFFIX=
+        set MILL_DOWNLOAD_FROM_MAVEN=0
+    )
+    if [!MILL_VERSION_PREFIX!]==[0.3.] (
+        set MILL_DOWNLOAD_SUFFIX=
+        set MILL_DOWNLOAD_FROM_MAVEN=0
+    )
+    if [!MILL_VERSION_PREFIX!]==[0.4.] (
+        set MILL_DOWNLOAD_SUFFIX=
+        set MILL_DOWNLOAD_FROM_MAVEN=0
+    )
+    if [!MILL_VERSION_PREFIX!]==[0.5.] set MILL_DOWNLOAD_FROM_MAVEN=0
+    if [!MILL_VERSION_PREFIX!]==[0.6.] set MILL_DOWNLOAD_FROM_MAVEN=0
+    if [!MILL_VERSION_PREFIX!]==[0.7.] set MILL_DOWNLOAD_FROM_MAVEN=0
+    if [!MILL_VERSION_PREFIX!]==[0.8.] set MILL_DOWNLOAD_FROM_MAVEN=0
+    if [!MILL_VERSION_PREFIX!]==[0.9.] set MILL_DOWNLOAD_FROM_MAVEN=0
+
+    set MILL_VERSION_PREFIX=%MILL_VERSION:~0,5%
+    if [!MILL_VERSION_PREFIX!]==[0.10.] set MILL_DOWNLOAD_FROM_MAVEN=0
+
+    set MILL_VERSION_PREFIX=%MILL_VERSION:~0,8%
+    if [!MILL_VERSION_PREFIX!]==[0.11.0-M] set MILL_DOWNLOAD_FROM_MAVEN=0
+
+    set MILL_VERSION_PREFIX=%MILL_VERSION:~0,5%
+    set DOWNLOAD_EXT=exe
+    if [!MILL_SHORT_VERSION_PREFIX!]==[0.] set DOWNLOAD_EXT=jar
+    if [!MILL_VERSION_PREFIX!]==[0.12.] set DOWNLOAD_EXT=exe
+    if [!MILL_VERSION!]==[0.12.0] set DOWNLOAD_EXT=jar
+    if [!MILL_VERSION!]==[0.12.1] set DOWNLOAD_EXT=jar
+    if [!MILL_VERSION!]==[0.12.2] set DOWNLOAD_EXT=jar
+    if [!MILL_VERSION!]==[0.12.3] set DOWNLOAD_EXT=jar
+    if [!MILL_VERSION!]==[0.12.4] set DOWNLOAD_EXT=jar
+    if [!MILL_VERSION!]==[0.12.5] set DOWNLOAD_EXT=jar
+    if [!MILL_VERSION!]==[0.12.6] set DOWNLOAD_EXT=jar
+    if [!MILL_VERSION!]==[0.12.7] set DOWNLOAD_EXT=jar
+    if [!MILL_VERSION!]==[0.12.8] set DOWNLOAD_EXT=jar
+    if [!MILL_VERSION!]==[0.12.9] set DOWNLOAD_EXT=jar
+    if [!MILL_VERSION!]==[0.12.10] set DOWNLOAD_EXT=jar
+    if [!MILL_VERSION!]==[0.12.11] set DOWNLOAD_EXT=jar
+
+    set MILL_VERSION_PREFIX=
+    set MILL_SHORT_VERSION_PREFIX=
+
+    for /F "delims=- tokens=1" %%A in ("!MILL_VERSION!") do set MILL_VERSION_BASE=%%A
+    set MILL_VERSION_MILESTONE=
+    for /F "delims=- tokens=2" %%A in ("!MILL_VERSION!") do set MILL_VERSION_MILESTONE=%%A
+    set MILL_VERSION_MILESTONE_START=!MILL_VERSION_MILESTONE:~0,1!
+    if [!MILL_VERSION_MILESTONE_START!]==[M] (
+        set MILL_VERSION_TAG=!MILL_VERSION_BASE!-!MILL_VERSION_MILESTONE!
+    ) else (
+        set MILL_VERSION_TAG=!MILL_VERSION_BASE!
+    )
+    if [!MILL_DOWNLOAD_FROM_MAVEN!]==[1] (
+        set MILL_DOWNLOAD_URL=https://repo1.maven.org/maven2/com/lihaoyi/mill-dist!ARTIFACT_SUFFIX!/!MILL_VERSION!/mill-dist!ARTIFACT_SUFFIX!-!MILL_VERSION!.!DOWNLOAD_EXT!
+    ) else (
+        set MILL_DOWNLOAD_URL=!MILL_GITHUB_RELEASE_CDN!%MILL_REPO_URL%/releases/download/!MILL_VERSION_TAG!/!MILL_VERSION!!MILL_DOWNLOAD_SUFFIX!
+    )
+
+    if defined MILL_TEST_DRY_RUN_LAUNCHER_SCRIPT (
+        echo !MILL_DOWNLOAD_URL!
+        echo !MILL!
+        exit /b 0
+    )
+
+    rem there seems to be no way to generate a unique temporary file path (on native Windows)
+    if defined MILL_OUTPUT_DIR (
+        set MILL_TEMP_DOWNLOAD_FILE=%MILL_OUTPUT_DIR%\mill-temp-download
+        if not exist "%MILL_OUTPUT_DIR%" mkdir "%MILL_OUTPUT_DIR%"
+    ) else (
+        set MILL_TEMP_DOWNLOAD_FILE=out\mill-bootstrap-download
+        if not exist "out" mkdir "out"
+    )
+
+    echo Downloading mill !MILL_VERSION! from !MILL_DOWNLOAD_URL! ... 1>&2
+
+    curl -f -L "!MILL_DOWNLOAD_URL!" -o "!MILL_TEMP_DOWNLOAD_FILE!"
+
+    if not exist "%MILL_FINAL_DOWNLOAD_FOLDER%" mkdir "%MILL_FINAL_DOWNLOAD_FOLDER%"
+    move /y "!MILL_TEMP_DOWNLOAD_FILE!" "%MILL%"
+
+    set MILL_TEMP_DOWNLOAD_FILE=
+    set MILL_DOWNLOAD_SUFFIX=
+)
+
+set MILL_FINAL_DOWNLOAD_FOLDER=
+set MILL_VERSION=
+set MILL_REPO_URL=
+
+rem Need to preserve the first position of those listed options
+set MILL_FIRST_ARG=
+if [%~1%]==[--bsp] (
+  set MILL_FIRST_ARG=%1%
+) else (
+  if [%~1%]==[-i] (
+    set MILL_FIRST_ARG=%1%
+  ) else (
+    if [%~1%]==[--interactive] (
+      set MILL_FIRST_ARG=%1%
+    ) else (
+      if [%~1%]==[--no-server] (
+        set MILL_FIRST_ARG=%1%
+      ) else (
+        if [%~1%]==[--no-daemon] (
+          set MILL_FIRST_ARG=%1%
+        ) else (
+          if [%~1%]==[--help] (
+            set MILL_FIRST_ARG=%1%
+          )
+        )
+      )
+    )
+  )
+)
+set "MILL_PARAMS=%*%"
+
+if not [!MILL_FIRST_ARG!]==[] (
+  for /f "tokens=1*" %%a in ("%*") do (
+    set "MILL_PARAMS=%%b"
+  )
+)
+
+rem -D mill.main.cli is for compatibility with Mill 0.10.9 - 0.13.0-M2
+"%MILL%" %MILL_FIRST_ARG% -D "mill.main.cli=%MILL_MAIN_CLI%" %MILL_PARAMS%

--- a/mill.bat
+++ b/mill.bat
@@ -2,7 +2,7 @@
 
 setlocal enabledelayedexpansion
 
-if [!DEFAULT_MILL_VERSION!]==[] ( set "DEFAULT_MILL_VERSION=1.1.5-21-53d1ba" )
+if [!DEFAULT_MILL_VERSION!]==[] ( set "DEFAULT_MILL_VERSION=1.1.6" )
 
 if [!MILL_GITHUB_RELEASE_CDN!]==[] ( set "MILL_GITHUB_RELEASE_CDN=" )
 

--- a/readme.md
+++ b/readme.md
@@ -508,7 +508,7 @@ requests.get(
 - Automatically handles sending/receiving/persisting cookies across
   multiple requests
 
-Note that sessions must be explicitly `close`d after use to prevent leakage 
+Note that sessions must be explicitly `close`d after use to prevent leakage
 of client threads and other resources
 
 ### Session Cookies

--- a/requests/src/requests/Requester.scala
+++ b/requests/src/requests/Requester.scala
@@ -5,8 +5,7 @@ import java.net.http._
 import java.net.{UnknownHostException => _, _}
 import java.nio.ByteBuffer
 import java.time.Duration
-import java.util.concurrent.{ExecutorService, Executors, Flow, ThreadFactory, TimeUnit}
-import java.util.function.Supplier
+import java.util.concurrent.{ExecutorService, Executors, Flow, ThreadFactory}
 import java.util.zip.{GZIPInputStream, InflaterInputStream}
 
 import scala.collection.JavaConverters._
@@ -52,12 +51,17 @@ trait BaseSession extends AutoCloseable {
     }
   })
   lazy val sharedHttpClient: HttpClient = BaseSession.buildHttpClient(
-    proxy, cert, sslContext, verifySslCerts, connectTimeout, executor
+    proxy,
+    cert,
+    sslContext,
+    verifySslCerts,
+    connectTimeout,
+    executor,
   )
 
   /**
-   * Closes the shared HttpClient and its executor. Call this when you're done
-   * with the session to release resources and prevent thread leaks.
+   * Closes the shared HttpClient and its executor. Call this when you're done with the session to
+   * release resources and prevent thread leaks.
    */
   def close(): Unit = {
     BaseSession.closeHttpClient(sharedHttpClient)
@@ -73,12 +77,12 @@ object BaseSession {
   )
 
   def buildHttpClient(
-    proxy: (String, Int),
-    cert: Cert,
-    sslContext: SSLContext,
-    verifySslCerts: Boolean,
-    connectTimeout: Int,
-    executor: ExecutorService
+      proxy: (String, Int),
+      cert: Cert,
+      sslContext: SSLContext,
+      verifySslCerts: Boolean,
+      connectTimeout: Int,
+      executor: ExecutorService,
   ): HttpClient = {
     val builder = HttpClient
       .newBuilder()
@@ -104,8 +108,8 @@ object BaseSession {
   }
 
   /**
-   * Closes an HttpClient, using reflection to handle both Java 21+ (which has close())
-   * and earlier versions (which require accessing internal selector).
+   * Closes an HttpClient, using reflection to handle both Java 21+ (which has close()) and earlier
+   * versions (which require accessing internal selector).
    */
   def closeHttpClient(httpClient: HttpClient): Unit = {
     try {
@@ -133,8 +137,8 @@ object BaseSession {
           case _: Exception =>
             System.err.println(
               "requests: Unable to close HttpClient SelectorManager thread. " +
-              "To fix thread leaks on Java <21, add JVM arg: " +
-              "--add-opens java.net.http/jdk.internal.net.http=ALL-UNNAMED"
+                "To fix thread leaks on Java <21, add JVM arg: " +
+                "--add-opens java.net.http/jdk.internal.net.http=ALL-UNNAMED",
             )
         }
     }
@@ -302,14 +306,22 @@ case class Requester(verb: String, sess: BaseSession) {
       // Check if we can reuse the session's shared HttpClient
       val useSharedClient =
         proxy == sess.proxy &&
-        cert == sess.cert &&
-        sslContext == sess.sslContext &&
-        verifySslCerts == sess.verifySslCerts &&
-        connectTimeout == sess.connectTimeout
+          cert == sess.cert &&
+          sslContext == sess.sslContext &&
+          verifySslCerts == sess.verifySslCerts &&
+          connectTimeout == sess.connectTimeout
 
       val httpClient: HttpClient =
         if (useSharedClient) sess.sharedHttpClient
-        else BaseSession.buildHttpClient(proxy, cert, sslContext, verifySslCerts, connectTimeout, sess.executor)
+        else
+          BaseSession.buildHttpClient(
+            proxy,
+            cert,
+            sslContext,
+            verifySslCerts,
+            connectTimeout,
+            sess.executor,
+          )
 
       try {
 
@@ -319,12 +331,12 @@ case class Requester(verb: String, sess: BaseSession) {
           if c.getDomain == null || c.getDomain == url1.getHost
           if c.getPath == null || url1.getPath.startsWith(c.getPath)
         } yield (c.getName, c.getValue)
-  
+
         val allCookies = sessionCookieValues ++ cookieValues
-  
+
         val (contentLengthHeader, otherBlobHeaders) =
           blobHeaders.partition(_._1.equalsIgnoreCase("Content-Length"))
-  
+
         val allHeaders =
           otherBlobHeaders ++
             sess.headers ++
@@ -369,23 +381,26 @@ case class Requester(verb: String, sess: BaseSession) {
           case _: HttpConnectTimeoutException | _: HttpTimeoutException =>
             throw new TimeoutException(url, readTimeout, connectTimeout)
           case e: java.net.UnknownHostException => throw new UnknownHostException(url, e.getMessage)
-          case e: java.nio.channels.UnresolvedAddressException => throw new UnknownHostException(url, e.getMessage)
+          case e: java.nio.channels.UnresolvedAddressException =>
+            throw new UnknownHostException(url, e.getMessage)
           case e: java.security.cert.CertificateException => throw new InvalidCertException(url, e)
-          case e: java.security.cert.CertPathValidatorException=> throw new InvalidCertException(url, e)
+          case e: java.security.cert.CertPathValidatorException =>
+            throw new InvalidCertException(url, e)
         }
 
         val response =
           try httpClient.send(requestBuilder.build(), HttpResponse.BodyHandlers.ofInputStream())
           catch {
             case e: Throwable =>
-              wrapError.lift(e)
-                // Sometimes the error we care about is wrapped in an IOException
-                // so check inside to see if there's something we want to handle
+              // Sometimes the error we care about is wrapped in an IOException
+              // so check inside to see if there's something we want to handle
+              wrapError
+                .lift(e)
                 .orElse(wrapError.lift(e.getCause))
                 .orElse(Option(e.getCause).flatMap(c => wrapError.lift(c.getCause)))
                 .getOrElse(throw new RequestsException(e.getMessage, Some(e)))
           }
-  
+
         val responseCode = response.statusCode()
         val headerFields =
           response
@@ -395,7 +410,7 @@ case class Requester(verb: String, sess: BaseSession) {
             .filter(_._1 != null)
             .map { case (k, v) => (k.toLowerCase(), v.asScala.toList) }
             .toMap
-  
+
         val deGzip = autoDecompress && headerFields
           .get("content-encoding")
           .toSeq
@@ -417,7 +432,7 @@ case class Requester(verb: String, sess: BaseSession) {
               .foreach(c => sess.cookies(c.getName) = c)
           }
         }
-  
+
         if (
           responseCode.toString.startsWith("3") &&
           responseCode.toString != "304" &&
@@ -426,7 +441,7 @@ case class Requester(verb: String, sess: BaseSession) {
           val out = new ByteArrayOutputStream()
           Util.transferTo(response.body, out)
           val bytes = out.toByteArray
-  
+
           val current = Response(
             url = url,
             statusCode = responseCode,
@@ -471,9 +486,9 @@ case class Requester(verb: String, sess: BaseSession) {
             history = redirectedFrom,
           )
           if (onHeadersReceived != null) onHeadersReceived(streamHeaders)
-  
+
           val stream = response.body()
-  
+
           def processWrappedStream[V](f: java.io.InputStream => V): V = {
             // The HEAD method is identical to GET except that the server
             // MUST NOT return a message-body in the response.
@@ -491,7 +506,7 @@ case class Requester(verb: String, sess: BaseSession) {
               f(new ByteArrayInputStream(Array()))
             }
           }
-  
+
           if (streamHeaders.statusCode == 304 || streamHeaders.is2xx || !check)
             processWrappedStream(f)
           else {

--- a/requests/src/requests/Requester.scala
+++ b/requests/src/requests/Requester.scala
@@ -51,17 +51,12 @@ trait BaseSession extends AutoCloseable {
     }
   })
   lazy val sharedHttpClient: HttpClient = BaseSession.buildHttpClient(
-    proxy,
-    cert,
-    sslContext,
-    verifySslCerts,
-    connectTimeout,
-    executor,
+    proxy, cert, sslContext, verifySslCerts, connectTimeout, executor
   )
 
   /**
-   * Closes the shared HttpClient and its executor. Call this when you're done with the session to
-   * release resources and prevent thread leaks.
+   * Closes the shared HttpClient and its executor. Call this when you're done
+   * with the session to release resources and prevent thread leaks.
    */
   def close(): Unit = {
     BaseSession.closeHttpClient(sharedHttpClient)
@@ -77,12 +72,12 @@ object BaseSession {
   )
 
   def buildHttpClient(
-      proxy: (String, Int),
-      cert: Cert,
-      sslContext: SSLContext,
-      verifySslCerts: Boolean,
-      connectTimeout: Int,
-      executor: ExecutorService,
+    proxy: (String, Int),
+    cert: Cert,
+    sslContext: SSLContext,
+    verifySslCerts: Boolean,
+    connectTimeout: Int,
+    executor: ExecutorService
   ): HttpClient = {
     val builder = HttpClient
       .newBuilder()
@@ -108,8 +103,8 @@ object BaseSession {
   }
 
   /**
-   * Closes an HttpClient, using reflection to handle both Java 21+ (which has close()) and earlier
-   * versions (which require accessing internal selector).
+   * Closes an HttpClient, using reflection to handle both Java 21+ (which has close())
+   * and earlier versions (which require accessing internal selector).
    */
   def closeHttpClient(httpClient: HttpClient): Unit = {
     try {
@@ -137,8 +132,8 @@ object BaseSession {
           case _: Exception =>
             System.err.println(
               "requests: Unable to close HttpClient SelectorManager thread. " +
-                "To fix thread leaks on Java <21, add JVM arg: " +
-                "--add-opens java.net.http/jdk.internal.net.http=ALL-UNNAMED",
+              "To fix thread leaks on Java <21, add JVM arg: " +
+              "--add-opens java.net.http/jdk.internal.net.http=ALL-UNNAMED"
             )
         }
     }
@@ -306,22 +301,14 @@ case class Requester(verb: String, sess: BaseSession) {
       // Check if we can reuse the session's shared HttpClient
       val useSharedClient =
         proxy == sess.proxy &&
-          cert == sess.cert &&
-          sslContext == sess.sslContext &&
-          verifySslCerts == sess.verifySslCerts &&
-          connectTimeout == sess.connectTimeout
+        cert == sess.cert &&
+        sslContext == sess.sslContext &&
+        verifySslCerts == sess.verifySslCerts &&
+        connectTimeout == sess.connectTimeout
 
       val httpClient: HttpClient =
         if (useSharedClient) sess.sharedHttpClient
-        else
-          BaseSession.buildHttpClient(
-            proxy,
-            cert,
-            sslContext,
-            verifySslCerts,
-            connectTimeout,
-            sess.executor,
-          )
+        else BaseSession.buildHttpClient(proxy, cert, sslContext, verifySslCerts, connectTimeout, sess.executor)
 
       try {
 
@@ -381,21 +368,18 @@ case class Requester(verb: String, sess: BaseSession) {
           case _: HttpConnectTimeoutException | _: HttpTimeoutException =>
             throw new TimeoutException(url, readTimeout, connectTimeout)
           case e: java.net.UnknownHostException => throw new UnknownHostException(url, e.getMessage)
-          case e: java.nio.channels.UnresolvedAddressException =>
-            throw new UnknownHostException(url, e.getMessage)
+          case e: java.nio.channels.UnresolvedAddressException => throw new UnknownHostException(url, e.getMessage)
           case e: java.security.cert.CertificateException => throw new InvalidCertException(url, e)
-          case e: java.security.cert.CertPathValidatorException =>
-            throw new InvalidCertException(url, e)
+          case e: java.security.cert.CertPathValidatorException=> throw new InvalidCertException(url, e)
         }
 
         val response =
           try httpClient.send(requestBuilder.build(), HttpResponse.BodyHandlers.ofInputStream())
           catch {
             case e: Throwable =>
-              // Sometimes the error we care about is wrapped in an IOException
-              // so check inside to see if there's something we want to handle
-              wrapError
-                .lift(e)
+              wrapError.lift(e)
+                // Sometimes the error we care about is wrapped in an IOException
+                // so check inside to see if there's something we want to handle
                 .orElse(wrapError.lift(e.getCause))
                 .orElse(Option(e.getCause).flatMap(c => wrapError.lift(c.getCause)))
                 .getOrElse(throw new RequestsException(e.getMessage, Some(e)))

--- a/requests/test/src-2/requests/Scala2RequestTests.scala
+++ b/requests/test/src-2/requests/Scala2RequestTests.scala
@@ -15,7 +15,7 @@ object Scala2RequestTests extends HttpbinTestSuite {
               chunkedUpload = chunkedUpload,
             )
             .text()
-          assert(read(res1).obj("form") == Obj("foo" -> "baz", "hello" -> "world"))
+          assert(read(res1).obj("form") == Obj("foo" -> Arr("baz"), "hello" -> Arr("world")))
         }
       }
 
@@ -28,7 +28,7 @@ object Scala2RequestTests extends HttpbinTestSuite {
               chunkedUpload = chunkedUpload,
             )
             .text()
-          assert(read(res1).obj("form") == Obj("foo" -> "baz", "hello" -> "world"))
+          assert(read(res1).obj("form") == Obj("foo" -> Arr("baz"), "hello" -> Arr("world")))
         }
       }
 
@@ -43,7 +43,7 @@ object Scala2RequestTests extends HttpbinTestSuite {
           )
           .text
 
-        assert(read(res1).obj("form") == Obj("foo" -> "baz", "hello" -> "world"))
+        assert(read(res1).obj("form") == Obj("foo" -> Arr("baz"), "hello" -> Arr("world")))
       }
     }
   }

--- a/requests/test/src-2/requests/Scala2RequestTests.scala
+++ b/requests/test/src-2/requests/Scala2RequestTests.scala
@@ -41,7 +41,7 @@ object Scala2RequestTests extends HttpbinTestSuite {
             data = Map("hello" -> "world", "foo" -> "baz"),
             chunkedUpload = true,
           )
-          .text
+          .text()
 
         assert(read(res1).obj("form") == Obj("foo" -> Arr("baz"), "hello" -> Arr("world")))
       }

--- a/requests/test/src/requests/HttpbinTestSuite.scala
+++ b/requests/test/src/requests/HttpbinTestSuite.scala
@@ -1,21 +1,38 @@
 package requests
 
-import com.dimafeng.testcontainers.GenericContainer
-import org.testcontainers.containers.wait.strategy.Wait
-import utest._
+import java.util.concurrent.ThreadLocalRandom
+import java.net.BindException
+
+import utest.TestSuite
 
 abstract class HttpbinTestSuite extends TestSuite {
-  private val containerDef = GenericContainer.Def(
-    "kennethreitz/httpbin",
-    exposedPorts = Seq(80),
-    waitStrategy = Wait.forHttp("/"),
-  )
-  private val container = containerDef.start()
+  // `GO_HTTPBIN_EXE` is defined in build.mill to get the path to go-httpbin cli
+  val httpbinPath = sys.env("GO_HTTPBIN_EXE")
 
-  val localHttpbin: String =
-    s"${container.containerIpAddress}:${container.mappedPort(80)}"
+  private val host = "127.0.0.1"
+  private var port = ThreadLocalRandom.current().nextInt(10000, 65535).toString()
+
+  private val httpbinProcess =
+    try {
+      val process =
+        os.proc(httpbinPath, "-host", host, "--port", port, "-log-level", "ERROR").spawn()
+      if (process.waitFor(500L)) {
+        if (process.stderr.lines().mkString.contains("address already in use"))
+          throw new BindException("Port is already in use")
+        else
+          throw new IllegalThreadStateException("`httpbin` process failed to start")
+      }
+      process
+    } catch {
+      case exc: BindException => {
+        port = ThreadLocalRandom.current().nextInt(10000, 65535).toString()
+        os.proc(httpbinPath, "-host", "127.0.0.1", "--port", port).spawn()
+      }
+    }
+
+  val localHttpbin: String = s"${host}:${port}"
 
   override def utestAfterAll(): Unit = {
-    container.stop()
+    httpbinProcess.destroy()
   }
 }

--- a/requests/test/src/requests/HttpbinTestSuite.scala
+++ b/requests/test/src/requests/HttpbinTestSuite.scala
@@ -1,6 +1,7 @@
 package requests
 
-import java.util.concurrent.ThreadLocalRandom
+import java.util.concurrent.{ThreadLocalRandom, Phaser}
+import java.util.concurrent.TimeUnit.MILLISECONDS
 import java.net.BindException
 
 import utest.TestSuite
@@ -14,25 +15,45 @@ abstract class HttpbinTestSuite extends TestSuite {
 
   private val httpbinProcess =
     try {
+      val phaser = new Phaser(1)
+      @volatile var portNotAvailable = false
       val process =
-        os.proc(httpbinPath, "-host", host, "--port", port, "-log-level", "ERROR").spawn()
+        os.proc(httpbinPath, "-host", host, "--port", port, "-log-level", "ERROR")
+          .spawn(
+            stderr = os.ProcessOutput.Readlines(lines => {
+              if (lines.contains("bind: address already in use"))
+                portNotAvailable = true
+              System.err.println("[httpbin stderr] " + lines)
+              if (!phaser.isTerminated()) phaser.arrive()
+            }),
+          )
       if (process.waitFor(500L)) {
-        if (process.stderr.lines().mkString.contains("address already in use"))
+        phaser.awaitAdvanceInterruptibly(0, 1000L, MILLISECONDS)
+        phaser.forceTermination()
+        if (portNotAvailable)
           throw new BindException("Port is already in use")
         else
-          throw new IllegalThreadStateException("`httpbin` process failed to start")
+          throw new IllegalStateException("`httpbin` process failed to start")
+      } else {
+        phaser.forceTermination()
       }
       process
     } catch {
       case exc: BindException => {
         port = ThreadLocalRandom.current().nextInt(10000, 65535).toString()
-        os.proc(httpbinPath, "-host", "127.0.0.1", "--port", port).spawn()
+        val retriedProc =
+          os.proc(httpbinPath, "-host", "127.0.0.1", "--port", port, "-log-level", "ERROR").spawn()
+        if (retriedProc.waitFor(500L)) {
+          throw new IllegalStateException("`httpbin` process failed to start")
+        }
+        retriedProc
       }
+
     }
 
   val localHttpbin: String = s"${host}:${port}"
 
   override def utestAfterAll(): Unit = {
-    httpbinProcess.destroy()
+    if (httpbinProcess.isAlive()) httpbinProcess.destroy()
   }
 }

--- a/requests/test/src/requests/RequestTests.scala
+++ b/requests/test/src/requests/RequestTests.scala
@@ -292,10 +292,7 @@ object RequestTests extends HttpbinTestSuite {
     }
 
     test("selfSignedCertificate") {
-      val res = requests.get(
-        "https://self-signed.badssl.com",
-        verifySslCerts = false,
-      )
+      val res = requests.get("https://self-signed.badssl.com", verifySslCerts = false)
       assert(res.statusCode == 200)
     }
 

--- a/requests/test/src/requests/RequestTests.scala
+++ b/requests/test/src/requests/RequestTests.scala
@@ -32,14 +32,21 @@ object RequestTests extends HttpbinTestSuite {
         // All in URL
         val res1 =
           requests.get(s"http://$localHttpbin/get?hello=world&foo=baz").text()
-        assert(read(res1).obj("args") == Obj("foo" -> "baz", "hello" -> "world"))
+        assert(read(res1).obj("args") == Obj("foo" -> Arr("baz"), "hello" -> Arr("world")))
+
+        // Multiple values for same key
+        val res11 =
+          requests.get(s"http://$localHttpbin/get?hello=world&foo=baz&foo=qux").text()
+        assert(
+          read(res11).obj("args") == Obj("foo" -> Arr("baz", "qux"), "hello" -> Arr("world")),
+        )
 
         // All in params
         val res2 = requests.get(
           s"http://$localHttpbin/get",
           params = Map("hello" -> "world", "foo" -> "baz"),
         )
-        assert(read(res2).obj("args") == Obj("foo" -> "baz", "hello" -> "world"))
+        assert(read(res2).obj("args") == Obj("foo" -> Arr("baz"), "hello" -> Arr("world")))
 
         // Mixed URL and params
         val res3 = requests
@@ -48,14 +55,14 @@ object RequestTests extends HttpbinTestSuite {
             params = Map("foo" -> "baz"),
           )
           .text()
-        assert(read(res3).obj("args") == Obj("foo" -> "baz", "hello" -> "world"))
+        assert(read(res3).obj("args") == Obj("foo" -> Arr("baz"), "hello" -> Arr("world")))
 
         // Needs escaping
         val res4 = requests.get(
           s"http://$localHttpbin/get?hello=world",
           params = Map("++-- lol" -> " !@#$%"),
         )
-        assert(read(res4).obj("args") == Obj("++-- lol" -> " !@#$%", "hello" -> "world"))
+        assert(read(res4).obj("args") == Obj("++-- lol" -> Arr(" !@#$%"), "hello" -> Arr("world")))
       }
     }
 
@@ -72,8 +79,8 @@ object RequestTests extends HttpbinTestSuite {
           )
           .text()
 
-        assert(read(response).obj("files") == Obj("file1" -> "Hello!"))
-        assert(read(response).obj("form") == Obj("file2" -> "Goodbye!"))
+        assert(read(response).obj("files") == Obj("file1" -> Arr("Hello!")))
+        assert(read(response).obj("form") == Obj("file2" -> Arr("Goodbye!")))
       }
     }
 
@@ -174,10 +181,10 @@ object RequestTests extends HttpbinTestSuite {
 
     test("decompress") {
       val res1 = requests.get(s"http://$localHttpbin/gzip")
-      assert(read(res1.text()).obj("headers").obj("Host").str == localHttpbin)
+      assert(read(res1.text()).obj("headers").obj("Host")(0).str == localHttpbin)
 
       val res2 = requests.get(s"http://$localHttpbin/deflate")
-      assert(read(res2).obj("headers").obj("Host").str == localHttpbin)
+      assert(read(res2).obj("headers").obj("Host")(0).str == localHttpbin)
 
       val res3 = requests.get(s"http://$localHttpbin/gzip", autoDecompress = false)
       assert(res3.bytes.length < res1.bytes.length)
@@ -203,23 +210,25 @@ object RequestTests extends HttpbinTestSuite {
 
       val res2 = requests.post(
         s"http://$localHttpbin/post",
+        headers = Map("Content-Type" -> "application/octet-stream"),
         compress = requests.Compress.Gzip,
         data = new RequestBlob.ByteSourceRequestBlob("I am cow"),
       )
       assert(
-        read(new String(res2.bytes))("data").toString
+        read(res2.text())("data")
+          .toString()
           .contains("data:application/octet-stream;base64,H4sIAAAAAA"),
       )
 
       val res3 = requests.post(
         s"http://$localHttpbin/post",
+        headers = Map("Content-Type" -> "application/octet-stream"),
         compress = requests.Compress.Deflate,
         data = new RequestBlob.ByteSourceRequestBlob("Hear me moo"),
       )
       assert(
-        read(new String(res3.bytes))(
-          "data",
-        ).toString == """"data:application/octet-stream;base64,eJzzSE0sUshNVcjNzwcAFokD3g=="""",
+        read(res3.text())("data").toString()
+          == """"data:application/octet-stream;base64,eJzzSE0sUshNVcjNzwcAFokD3g=="""",
       )
     }
 
@@ -227,9 +236,9 @@ object RequestTests extends HttpbinTestSuite {
       test("default") {
         val res = requests.get(s"http://$localHttpbin/headers").text()
         val hs = read(res)("headers").obj
-        assert(hs("User-Agent").str == "requests-scala")
-        assert(hs("Accept-Encoding").str == "gzip, deflate")
-        assert(hs("Accept").str == "*/*")
+        assert(hs("User-Agent") == Arr("requests-scala"))
+        assert(hs("Accept-Encoding") == Arr("gzip, deflate"))
+        assert(hs("Accept") == Arr("*/*"))
         test("hasNoCookie") {
           assert(!hs.contains("Cookie"))
         }
@@ -327,7 +336,7 @@ object RequestTests extends HttpbinTestSuite {
         headers = Seq("x-y" -> "a", "x-y" -> "b"),
       )
       // make sure it's not "a,b"
-      assert(ujson.read(res)("headers")("X-Y") == Str("b"))
+      assert(ujson.read(res)("headers")("X-Y") == Arr("b"))
     }
   }
 }

--- a/requests/test/src/requests/RequestTests.scala
+++ b/requests/test/src/requests/RequestTests.scala
@@ -300,7 +300,7 @@ object RequestTests extends HttpbinTestSuite {
     }
 
     test("gzipError") {
-      val response = requests.head("https://api.github.com/users/lihaoyi")
+      val response = requests.head("https://www.apple.com")
       assert(response.statusCode == 200)
       assert(response.data.array.isEmpty)
       assert(response.headers.keySet.map(_.toLowerCase).contains("content-length"))

--- a/requests/test/src/requests/RequestTests.scala
+++ b/requests/test/src/requests/RequestTests.scala
@@ -19,7 +19,7 @@ object RequestTests extends HttpbinTestSuite {
             val res = r(s"$baseUrl/${r2.verb.toLowerCase()}")
             assert(res.statusCode == 200)
           } else {
-            intercept[RequestFailedException] {
+            assertThrows[RequestFailedException] {
               r(s"$baseUrl/${r2.verb.toLowerCase()}")
             }
           }
@@ -141,16 +141,16 @@ object RequestTests extends HttpbinTestSuite {
 
     test("timeouts") {
       test("read") {
-        intercept[TimeoutException] {
+        assertThrows[TimeoutException] {
           requests.get(s"http://$localHttpbin/delay/1", readTimeout = 10)
         }
         requests.get(s"http://$localHttpbin/delay/1", readTimeout = 2000)
-        intercept[TimeoutException] {
+        assertThrows[TimeoutException] {
           requests.get(s"http://$localHttpbin/delay/3", readTimeout = 2000)
         }
       }
       test("connect") {
-        intercept[TimeoutException] {
+        assertThrows[TimeoutException] {
           // use remote httpbin.org so it needs more time to connect
           requests.get(s"https://httpbin.org/delay/1", connectTimeout = 1)
         }
@@ -158,16 +158,16 @@ object RequestTests extends HttpbinTestSuite {
     }
 
     test("failures") {
-      intercept[UnknownHostException] {
+      assertThrows[UnknownHostException] {
         requests.get("https://doesnt-exist-at-all.com/")
       }
-      intercept[InvalidCertException] {
+      assertThrows[InvalidCertException] {
         requests.get("https://expired.badssl.com/")
       }
 
       requests.get("https://expired.badssl.com/", verifySslCerts = false)
 
-      intercept[java.net.MalformedURLException] {
+      assertThrows[java.net.MalformedURLException] {
         requests.get("://doesnt-exist.com/")
       }
     }
@@ -303,9 +303,9 @@ object RequestTests extends HttpbinTestSuite {
      * can compare
      */
     test("compressionData") {
-      import requests.Compress._
+      import requests.Compress
       val str = "I am deflater mouse"
-      Seq(None, Gzip, Deflate).foreach { c =>
+      Seq(Compress.None, Compress.Gzip, Compress.Deflate).foreach { c =>
         ServerUtils.usingEchoServer { port =>
           val response =
             requests.post(

--- a/requests/test/src/requests/RequestTests.scala
+++ b/requests/test/src/requests/RequestTests.scala
@@ -150,7 +150,7 @@ object RequestTests extends HttpbinTestSuite {
         }
       }
       test("connect") {
-        intercept[TimeoutException] {
+        assertThrows[TimeoutException] {
           // use unreachable IP address to test connect timeout (more reliable than remote httpbin.org)
           requests.get("http://10.255.255.1:12345/", connectTimeout = 1)
         }
@@ -331,4 +331,3 @@ object RequestTests extends HttpbinTestSuite {
     }
   }
 }
-


### PR DESCRIPTION
Hi Haoyi,

This PR is part of #156, I've been working on integrating my `scala-native-http` implementation into requests-scala to see what's still missed.

For better compatibility across JVM and Native, I've upgrade to the main deps `utest` (from 0.7.10 to `0.9.5`) and `ujson` (from `1.3.13` to `4.4.3`), this means all our core deps (`geny`, `utest`, `ujson`) already support Scala Native.

As a result, `intercept` has been deprecated from `utest`, so I rewrote all `intercept` call to `assertThrows` in this PR.

However, we still have two tricky parts to handle: `com.dimafeng::testcontainers-scala` and `com.sun.net.httpserver`. The good news is they're just test helpers and replaceable.

I found other well maintained alternative of `httpbin` [gh:mccutchen/go-httpbin](https://github.com/mccutchen/go-httpbin) written in GO lang, which could distribute as single binary.

Hence, I plan in next PR to refactor `HttpbinTestSuite` to

```
abstract class HttpbinTestSuite extends TestSuite {

  // Download single executable binary from GitHub release page directy
  // May implement in `build.mill` and lazy call when we actually run tests.

  // Add retry logic if port is in use
  private val host = "localhost"
  private val port: Int = random()
  private val httpBinProcess = os.proc("httpbin-go", ..., ...)

  val localHttpbin: String =
    s"${host}:${port}"

  override def utestAfterAll(): Unit = {
    // send exit signal to httpbin process or kill it
    ???
  }
}
```

Then, This would be perfect for setting up a mock http server for both JVM and Native, and also for Windows OS.

It's a pity that the [upstream](https://github.com/mccutchen/go-httpbin) doesn't offer pre-built binaries yet. So, I've opened an issue mccutchen/go-httpbin#242 (also ask about an echo server feature, then we can deprecate `sun.HttpServer`) and try to collaborate with upstream to address it.

How about your opinions? Looking forward to them.

Cheers,
Lanqing

Address other issues:

- Close #226
- Close #214 
- Close #207 
- Close #199 
- Close #195 
- Close #187 
- Close #186
- Close #184 
- Close #183 
- Close #131 

---

PR Update Apr 22, 2026

Upstream has helped me address the binary artifact release, so I appended some improvements for the httpbin test kits to this PR. The main incremental changes after [previous done commits](https://github.com/com-lihaoyi/requests-scala/pull/222/changes/1cfb2fb13015071a248689a19b4bb2d3a4743158):

1. Replace `testcontainers-scala` in favor of `mccutchen/go-httpbin`
2. Understand and align the different behaviors between `mccutchen/go-httpbin` and `kennethreitz/httpbin`
   - See [thread](https://github.com/com-lihaoyi/requests-scala/pull/222#discussion_r3128428690) to check more concrete details
3. Upgrade mill to 1.1.5
   - side effect: The minimal JVM version **in CI** become 17 now
     ```
     Invalid java.version 11.0.30. Mill requires Java 17 and above to run the build tool itself. Individual `JavaModule` can be set to lower Java versions via `def jvmVersion = "11"`
     ```
4. Upgrade version of actions and add CI pipeline on macOS

Some attempted updates but I eventually reverted:

1. Tried to upgrade `ScalaNextVersion` to 3.8.3, but it failed in binary compatibility check
   - ci log: https://github.com/com-lihaoyi/requests-scala/actions/runs/24725196688/job/72324200074#step:3:633
2. Tried to add a CI pipeline for Windows, but it failed during the cert bundle parsing
   - ci log: https://github.com/com-lihaoyi/requests-scala/actions/runs/24759357647/job/72439599258#step:3:910
   - This failure is **unrelated to the code changes in this PR**, I would plan to fix it in a future PR.
   - > Our `scala-native-http` has supported Windows now!
   - > The good news is at least the new `httpbin` test kit works as expected on Windows

Overall, we can now deprecate `com.dimafeng::testcontainers-scala`, leaving only `sun.HttpServer` behind
