### PR TITLE
Fix: Replace remote httpbin.org with unreachable IP for connect timeout test

### DIFF
--- a/requests/test/src/requests/RequestTests.scala
+++ b/requests/test/src/requests/RequestTests.scala
@@ -151,8 +151,8 @@ object RequestTests extends HttpbinTestSuite {
       }
       test("connect") {
         intercept[TimeoutException] {
-          // use remote httpbin.org so it needs more time to connect
-          requests.get(s"https://httpbin.org/delay/1", connectTimeout = 1)
+          // use unreachable IP address to test connect timeout (more reliable than remote httpbin.org)
+          requests.get("http://10.255.255.1:12345/", connectTimeout = 1)
         }
       }
     }
@@ -331,3 +331,4 @@ object RequestTests extends HttpbinTestSuite {
     }
   }
 }
+


### PR DESCRIPTION
Fixes #1219. Replaced remote httpbin.org with unreachable IP address for reliable connect timeout testing.