### PR TITLE
fix: use HTTPBIN_URL env var for CI, fall back to testcontainers locally

### DIFF
--- a/requests/test/src/requests/HttpbinTestSuite.scala
+++ b/requests/test/src/requests/HttpbinTestSuite.scala
@@ -5,17 +5,27 @@ import org.testcontainers.containers.wait.strategy.Wait
 import utest._
 
 abstract class HttpbinTestSuite extends TestSuite {
-  private val containerDef = GenericContainer.Def(
-    "kennethreitz/httpbin",
-    exposedPorts = Seq(80),
-    waitStrategy = Wait.forHttp("/"),
-  )
-  private val container = containerDef.start()
+  // CI fallback: use HTTPBIN_URL env var (set by GitHub Actions service container)
+  // If not set, fall back to testcontainers (for local development)
+  private val useTestcontainers: Boolean = sys.env.get("HTTPBIN_URL").isEmpty
 
-  val localHttpbin: String =
-    s"${container.containerIpAddress}:${container.mappedPort(80)}"
+  private val (container, localHttpbinHost) = if (useTestcontainers) {
+    val containerDef = GenericContainer.Def(
+      "kennethreitz/httpbin",
+      exposedPorts = Seq(80),
+      waitStrategy = Wait.forHttp("/"),
+    )
+    val c = containerDef.start()
+    val host = s"${c.containerIpAddress}:${c.mappedPort(80)}"
+    (Some(c), host)
+  } else {
+    val httpbinUrl = sys.env("HTTPBIN_URL")
+    (None, httpbinUrl.replace("http://", "").replace("https://", ""))
+  }
+
+  val localHttpbin: String = localHttpbinHost
 
   override def utestAfterAll(): Unit = {
-    container.stop()
+    container.foreach(_.stop())
   }
 }


### PR DESCRIPTION
## Summary

Fixes https://github.com/lihaoyi/test/issues/1219 - `requests.RequestTests` timing out connecting to external `httpbin.org`.

### Problem
Tests were failing in CI with timeouts connecting to `https://httpbin.org`. The `kennethreitz/httpbin` Docker image via testcontainers may not start reliably in GitHub Actions without DinD configuration.

### Solution
`HttpbinTestSuite` now checks for `HTTPBIN_URL` environment variable first:
- **CI**: Set `HTTPBIN_URL=http://localhost:8080` via GitHub Actions service container
- **Local dev**: Falls back to testcontainers Docker container (existing behavior)

### CI Change Needed
Add to `.github/workflows/actions.yml`:
```yaml
jobs:
  test:
    runs-on: ubuntu-latest
    services:
      httpbin:
        image: kennethreitz/httpbin:latest
        ports:
          - 8080:80
    steps:
      - uses: actions/checkout@v4
      - name: Run tests
        run: ./mill -i __.test
        env:
          HTTPBIN_URL: "http://localhost:8080"
```

### Testing
- Local: `./mill -i __.test` (uses testcontainers automatically)
- CI: Set `HTTPBIN_URL` env var to use the service container