### PR TITLE
refactor: Improve runtime reflections and re-implement HTTP Echo Server with `http4s`

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -21,12 +21,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: ['11', '17', '21']
+        java: ['17', '21', '25']
     steps:
       - uses: actions/checkout@v4
       - name: Run tests
         run: |
-          sed -i 's#//| mill-jvm-version: 11#//| mill-jvm-version: ${{ matrix.java }}#' build.mill
+          sed -i 's#//| mill-jvm-version: 25#//| mill-jvm-version: ${{ matrix.java }}#' build.mill
           ./mill -i -DscalaNextVersion=${{ env.SCALA_NEXT_VERSION }} __.publishArtifacts + __.test
 
   check-binary-compatibility:

--- a/build.mill
+++ b/build.mill
@@ -4,6 +4,8 @@
 //| - com.github.lolgab::mill-mima_mill1:0.2.0
 package build
 
+import scala.util.Properties
+
 import mill._
 import scalalib._
 import scalanativelib._
@@ -47,7 +49,9 @@ trait RequestsPublishModule extends PublishModule with MimaCheck {
 
 trait RequestsCrossScalaModule extends CrossScalaModule with ScalaModule {
   def moduleDir = build.moduleDir / "requests"
-  def sources = Task.Sources("src")
+
+  // Default sources for JDK 21+ and Scala Native
+  def sources = Task.Sources("src", "src-modern")
 }
 
 trait RequestsTestModule extends TestModule.Utest {
@@ -62,7 +66,18 @@ trait RequestsTestModule extends TestModule.Utest {
 }
 
 object requests extends Module {
-  trait RequestsJvmModule extends RequestsCrossScalaModule with RequestsPublishModule {
+  trait RequestsJvmModule extends RequestsCrossScalaModule {
+    private def runtimeJvmMajorVersion = Task {
+      val customJvmVer = jvmVersion()
+      val runtimeJvmVer = if (!customJvmVer.isEmpty()) jvmVersion() else Properties.javaVersion
+      runtimeJvmVer.split('.').head.toInt
+    }
+    private def legacySources = Task.Sources("src", "src-legacy")
+
+    override def sources = Task {
+      if (runtimeJvmMajorVersion() >= 21) super.sources() else legacySources()
+    }
+
     object test extends ScalaTests with RequestsTestModule
   }
   object jvm extends Cross[RequestsJvmModule](scalaVersions)

--- a/build.mill
+++ b/build.mill
@@ -1,5 +1,5 @@
-//| mill-version: 1.1.0-RC1
-//| mill-jvm-version: 11
+//| mill-version: 1.1.6
+//| mill-jvm-version: 25
 //| mvnDeps:
 //| - com.github.lolgab::mill-mima_mill1:0.2.0
 package build
@@ -20,7 +20,7 @@ val scalaVersions = List("2.12.20", "2.13.15", "3.3.4") ++ scalaNextVersion ++ c
 val scalaNativeVer = "0.5.6"
 
 trait MimaCheck extends Mima {
-   def mimaPreviousVersions = Seq("0.6.9", "0.7.0", "0.7.1", "0.8.0","0.8.2", "0.9.0").distinct
+  def mimaPreviousVersions = Seq("0.6.9", "0.7.0", "0.7.1", "0.8.0","0.8.2", "0.9.0").distinct
 
   override def mimaBinaryIssueFilters = Seq(
     ProblemFilter.exclude[ReversedMissingMethodProblem]("requests.BaseSession.send"),
@@ -47,7 +47,8 @@ trait RequestsPublishModule extends PublishModule with MimaCheck {
   def mvnDeps = Seq(mvn"com.lihaoyi::geny::1.1.1")
 }
 
-trait RequestsCrossScalaModule extends CrossScalaModule with ScalaModule {
+trait RequestsCrossScalaModule
+  extends CrossScalaModule with ScalaModule with RequestsPublishModule {
   def moduleDir = build.moduleDir / "requests"
 
   // Default sources for JDK 21+ and Scala Native
@@ -58,7 +59,9 @@ trait RequestsTestModule extends TestModule.Utest {
   def mvnDeps = Seq(
     mvn"com.lihaoyi::utest::0.7.10",
     mvn"com.lihaoyi::ujson::1.3.13",
-    mvn"com.dimafeng::testcontainers-scala-core:0.43.0"
+    mvn"com.dimafeng::testcontainers-scala-core:0.43.0",
+    mvn"org.http4s::http4s-dsl::0.23.36",
+    mvn"org.http4s::http4s-ember-server::0.23.36",
   )
   def forkArgs = Seq(
     "--add-opens", "java.net.http/jdk.internal.net.http=ALL-UNNAMED"

--- a/requests/src-legacy/requests/CompatUtil.scala
+++ b/requests/src-legacy/requests/CompatUtil.scala
@@ -1,0 +1,33 @@
+package requests
+
+import java.net.http.HttpClient
+
+private object CompatUtil {
+  // Java < 21: use reflection to access internal selectorManager and close its selector
+  // HttpClient.newBuilder().build() returns HttpClientFacade which wraps HttpClientImpl
+  @inline
+  final def closeHttpClient(httpClient: HttpClient): Unit =
+    try {
+      val facadeClass = httpClient.getClass()
+      val implField = facadeClass.getDeclaredField("impl")
+      implField.setAccessible(true)
+      val impl = implField.get(httpClient)
+      val selectorManagerField = impl.getClass.getDeclaredField("selmgr")
+      selectorManagerField.setAccessible(true)
+      val selectorManager = selectorManagerField.get(impl)
+      // SelectorManager has a 'selector' field we can close
+      val selectorField = selectorManager.getClass.getDeclaredField("selector")
+      selectorField.setAccessible(true)
+      val selector = selectorField.get(selectorManager)
+      val closeMethod = selector.getClass.getMethod("close")
+      closeMethod.invoke(selector)
+    } catch {
+      case _: Exception =>
+        System.err.println(
+          "requests: Unable to close HttpClient SelectorManager thread. " +
+            "To fix thread leaks on Java <21, add JVM arg: " +
+            "--add-opens java.net.http/jdk.internal.net.http=ALL-UNNAMED",
+        )
+    }
+
+}

--- a/requests/src-modern/src-modern/CompatUtil.scala
+++ b/requests/src-modern/src-modern/CompatUtil.scala
@@ -1,0 +1,10 @@
+package requests
+
+import java.net.http.HttpClient
+
+private object CompatUtil {
+  // For JDK 21+ and Scala Native
+  @inline
+  final def closeHttpClient(httpClient: HttpClient): Unit =
+    httpClient.close()
+}

--- a/requests/src/requests/Requester.scala
+++ b/requests/src/requests/Requester.scala
@@ -3,10 +3,10 @@ package requests
 import java.io._
 import java.net.http._
 import java.net.{UnknownHostException => _, _}
+import java.net.URL
 import java.nio.ByteBuffer
 import java.time.Duration
-import java.util.concurrent.{ExecutorService, Executors, Flow, ThreadFactory, TimeUnit}
-import java.util.function.Supplier
+import java.util.concurrent.{ExecutorService, Executors, Flow, ThreadFactory}
 import java.util.zip.{GZIPInputStream, InflaterInputStream}
 
 import scala.collection.JavaConverters._
@@ -56,8 +56,8 @@ trait BaseSession extends AutoCloseable {
   )
 
   /**
-   * Closes the shared HttpClient and its executor. Call this when you're done
-   * with the session to release resources and prevent thread leaks.
+   * Closes the shared HttpClient and its executor. Call this when you're done with the session to
+   * release resources and prevent thread leaks.
    */
   def close(): Unit = {
     BaseSession.closeHttpClient(sharedHttpClient)
@@ -78,7 +78,7 @@ object BaseSession {
     sslContext: SSLContext,
     verifySslCerts: Boolean,
     connectTimeout: Int,
-    executor: ExecutorService
+    executor: ExecutorService,
   ): HttpClient = {
     val builder = HttpClient
       .newBuilder()
@@ -104,8 +104,8 @@ object BaseSession {
   }
 
   /**
-   * Closes an HttpClient, using reflection to handle both Java 21+ (which has close())
-   * and earlier versions (which require accessing internal selector).
+   * Closes an HttpClient, using reflection to handle both Java 21+ (which has close()) and earlier
+   * versions (which require accessing internal selector).
    */
   def closeHttpClient(httpClient: HttpClient): Unit = {
     try {
@@ -134,7 +134,7 @@ object BaseSession {
             System.err.println(
               "requests: Unable to close HttpClient SelectorManager thread. " +
               "To fix thread leaks on Java <21, add JVM arg: " +
-              "--add-opens java.net.http/jdk.internal.net.http=ALL-UNNAMED"
+              "--add-opens java.net.http/jdk.internal.net.http=ALL-UNNAMED",
             )
         }
     }
@@ -290,13 +290,11 @@ case class Requester(verb: String, sess: BaseSession) {
       onHeadersReceived: StreamHeaders => Unit = null,
   ): geny.Readable = new geny.Readable {
     def readBytesThrough[T](f: java.io.InputStream => T): T = {
-
-      val url0 = new java.net.URL(url)
-
+      val url0 = new URL(url)
       val url1 = if (params.nonEmpty) {
         val encodedParams = Util.urlEncode(params)
         val firstSep = if (url0.getQuery != null) "&" else "?"
-        new java.net.URL(url + firstSep + encodedParams)
+        new URL(url + firstSep + encodedParams)
       } else url0
 
       // Check if we can reuse the session's shared HttpClient
@@ -312,19 +310,18 @@ case class Requester(verb: String, sess: BaseSession) {
         else BaseSession.buildHttpClient(proxy, cert, sslContext, verifySslCerts, connectTimeout, sess.executor)
 
       try {
-
         val sessionCookieValues = for {
           c <- (sess.cookies ++ cookies).valuesIterator
           if !c.hasExpired
-          if c.getDomain == null || c.getDomain == url1.getHost
-          if c.getPath == null || url1.getPath.startsWith(c.getPath)
-        } yield (c.getName, c.getValue)
-  
+          if c.getDomain() == null || c.getDomain() == url1.getHost()
+          if c.getPath() == null || url1.getPath().startsWith(c.getPath())
+        } yield (c.getName(), c.getValue())
+
         val allCookies = sessionCookieValues ++ cookieValues
-  
+
         val (contentLengthHeader, otherBlobHeaders) =
           blobHeaders.partition(_._1.equalsIgnoreCase("Content-Length"))
-  
+
         val allHeaders =
           otherBlobHeaders ++
             sess.headers ++
@@ -350,7 +347,7 @@ case class Requester(verb: String, sess: BaseSession) {
         // Buffer the request body
         val requestBodyBuffer = new ByteArrayOutputStream()
         usingOutputStream(compress.wrap(requestBodyBuffer)) { os => data.write(os) }
-        val requestBodyBytes = requestBodyBuffer.toByteArray
+        val requestBodyBytes = requestBodyBuffer.toByteArray()
 
         val bodyPublisher: HttpRequest.BodyPublisher =
           if (requestBodyBytes.isEmpty) HttpRequest.BodyPublishers.noBody()
@@ -359,19 +356,18 @@ case class Requester(verb: String, sess: BaseSession) {
         val requestBuilder =
           HttpRequest
             .newBuilder()
-            .uri(url1.toURI)
+            .uri(url1.toURI())
             .timeout(Duration.ofMillis(readTimeout))
             .headers(headersKeyValueAlternating: _*)
             .method(upperCaseVerb, bodyPublisher)
 
         def wrapError: PartialFunction[Throwable, Nothing] = {
           case e: javax.net.ssl.SSLException => throw new InvalidCertException(url, e)
-          case _: HttpConnectTimeoutException | _: HttpTimeoutException =>
-            throw new TimeoutException(url, readTimeout, connectTimeout)
-          case e: java.net.UnknownHostException => throw new UnknownHostException(url, e.getMessage)
+          case _: HttpConnectTimeoutException | _: HttpTimeoutException => throw new TimeoutException(url, readTimeout, connectTimeout)
+          case e: java.net.UnknownHostException => throw new UnknownHostException(url, e.getMessage())
           case e: java.nio.channels.UnresolvedAddressException => throw new UnknownHostException(url, e.getMessage)
           case e: java.security.cert.CertificateException => throw new InvalidCertException(url, e)
-          case e: java.security.cert.CertPathValidatorException=> throw new InvalidCertException(url, e)
+          case e: java.security.cert.CertPathValidatorException => throw new InvalidCertException(url, e)
         }
 
         val response =
@@ -385,7 +381,7 @@ case class Requester(verb: String, sess: BaseSession) {
                 .orElse(Option(e.getCause).flatMap(c => wrapError.lift(c.getCause)))
                 .getOrElse(throw new RequestsException(e.getMessage, Some(e)))
           }
-  
+
         val responseCode = response.statusCode()
         val headerFields =
           response
@@ -395,7 +391,7 @@ case class Requester(verb: String, sess: BaseSession) {
             .filter(_._1 != null)
             .map { case (k, v) => (k.toLowerCase(), v.asScala.toList) }
             .toMap
-  
+
         val deGzip = autoDecompress && headerFields
           .get("content-encoding")
           .toSeq
@@ -414,10 +410,10 @@ case class Requester(verb: String, sess: BaseSession) {
               .iterator
               .flatten
               .flatMap(HttpCookie.parse(_).asScala)
-              .foreach(c => sess.cookies(c.getName) = c)
+              .foreach(c => sess.cookies(c.getName()) = c)
           }
         }
-  
+
         if (
           responseCode.toString.startsWith("3") &&
           responseCode.toString != "304" &&
@@ -425,8 +421,8 @@ case class Requester(verb: String, sess: BaseSession) {
         ) {
           val out = new ByteArrayOutputStream()
           Util.transferTo(response.body, out)
-          val bytes = out.toByteArray
-  
+          val bytes = out.toByteArray()
+
           val current = Response(
             url = url,
             statusCode = responseCode,
@@ -438,7 +434,7 @@ case class Requester(verb: String, sess: BaseSession) {
           persistCookies()
           val newUrl = current.headers("location").head
           stream(
-            url = new URL(url1, newUrl).toString,
+            url = new URL(url1, newUrl).toString(),
             auth = auth,
             params = params,
             blobHeaders = blobHeaders,
@@ -471,9 +467,9 @@ case class Requester(verb: String, sess: BaseSession) {
             history = redirectedFrom,
           )
           if (onHeadersReceived != null) onHeadersReceived(streamHeaders)
-  
+
           val stream = response.body()
-  
+
           def processWrappedStream[V](f: java.io.InputStream => V): V = {
             // The HEAD method is identical to GET except that the server
             // MUST NOT return a message-body in the response.
@@ -491,7 +487,7 @@ case class Requester(verb: String, sess: BaseSession) {
               f(new ByteArrayInputStream(Array()))
             }
           }
-  
+
           if (streamHeaders.statusCode == 304 || streamHeaders.is2xx || !check)
             processWrappedStream(f)
           else {
@@ -502,7 +498,7 @@ case class Requester(verb: String, sess: BaseSession) {
                 url = streamHeaders.url,
                 statusCode = streamHeaders.statusCode,
                 statusMessage = streamHeaders.statusMessage,
-                data = new geny.Bytes(errorOutput.toByteArray),
+                data = new geny.Bytes(errorOutput.toByteArray()),
                 headers = streamHeaders.headers,
                 history = streamHeaders.history,
               ),

--- a/requests/src/requests/Requester.scala
+++ b/requests/src/requests/Requester.scala
@@ -107,47 +107,11 @@ object BaseSession {
    * Closes an HttpClient, using reflection to handle both Java 21+ (which has close()) and earlier
    * versions (which require accessing internal selector).
    */
-  def closeHttpClient(httpClient: HttpClient): Unit = {
-    try {
-      val closeMethod = classOf[HttpClient].getMethod("close")
-      closeMethod.invoke(httpClient)
-    } catch {
-      case _: NoSuchMethodException =>
-        // Java < 21: use reflection to access internal selectorManager and close its selector
-        // HttpClient.newBuilder().build() returns HttpClientFacade which wraps HttpClientImpl
-        try {
-          val facadeClass = httpClient.getClass
-          val implField = facadeClass.getDeclaredField("impl")
-          implField.setAccessible(true)
-          val impl = implField.get(httpClient)
-          val selectorManagerField = impl.getClass.getDeclaredField("selmgr")
-          selectorManagerField.setAccessible(true)
-          val selectorManager = selectorManagerField.get(impl)
-          // SelectorManager has a 'selector' field we can close
-          val selectorField = selectorManager.getClass.getDeclaredField("selector")
-          selectorField.setAccessible(true)
-          val selector = selectorField.get(selectorManager)
-          val closeMethod = selector.getClass.getMethod("close")
-          closeMethod.invoke(selector)
-        } catch {
-          case _: Exception =>
-            System.err.println(
-              "requests: Unable to close HttpClient SelectorManager thread. " +
-              "To fix thread leaks on Java <21, add JVM arg: " +
-              "--add-opens java.net.http/jdk.internal.net.http=ALL-UNNAMED",
-            )
-        }
-    }
-  }
+  def closeHttpClient(httpClient: HttpClient): Unit = CompatUtil.closeHttpClient(httpClient)
 }
 
 object Requester {
   val officialHttpMethods = Set("GET", "POST", "HEAD", "OPTIONS", "PUT", "DELETE", "TRACE")
-  private lazy val methodField: java.lang.reflect.Field = {
-    val m = classOf[HttpURLConnection].getDeclaredField("method")
-    m.setAccessible(true)
-    m
-  }
 }
 
 case class Requester(verb: String, sess: BaseSession) {

--- a/requests/test/src/requests/ModelTests.scala
+++ b/requests/test/src/requests/ModelTests.scala
@@ -7,11 +7,14 @@ import java.nio.file.{FileSystems, Path}
 import utest._
 
 object ModelTests extends TestSuite {
+
+  val RESOURCE_DIR = sys.env("MILL_TEST_RESOURCE_DIR")
+
   val tests = Tests {
     test("multipart file uploads should contain application/octet-stream content type") {
-      val path = getClass.getResource("/license.zip").getPath
+      val path = s"${RESOURCE_DIR}/license.zip"
       val file = new File(path)
-      val nioPath = FileSystems.getDefault.getPath(path)
+      val nioPath = FileSystems.getDefault().getPath(path)
       val fileKey = "fileKey"
       val fileName = "fileName"
 

--- a/requests/test/src/requests/ServerUtils.scala
+++ b/requests/test/src/requests/ServerUtils.scala
@@ -1,12 +1,17 @@
 package requests
 
-import com.sun.net.httpserver.{HttpExchange, HttpHandler, HttpServer}
 import java.io._
-import java.net.InetSocketAddress
 import java.util.zip.{GZIPInputStream, InflaterInputStream}
-import requests.Compress._
+
 import scala.annotation.tailrec
 import scala.collection.mutable.StringBuilder
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import com.comcast.ip4s._
+import org.http4s.HttpRoutes
+import org.http4s.dsl.io._
+import org.http4s.ember.server.EmberServerBuilder
 
 object ServerUtils {
   def usingEchoServer(f: Int => Unit): Unit = {
@@ -15,36 +20,36 @@ object ServerUtils {
     finally server.stop()
   }
 
-  private class EchoServer extends HttpHandler {
-    private val server: HttpServer =
-      HttpServer.create(new InetSocketAddress(0), 0)
-    server.createContext("/echo", this)
-    server.setExecutor(null); // default executor
-    server.start()
+  private class EchoServer {
+    private val ember = EmberServerBuilder
+      .default[IO]
+      .withHost(ipv4"127.0.0.1")
+      .withPort(port"0")
+      .withHttpApp(echoRoutes.orNotFound)
+      .build
+      .allocated
+      .unsafeRunSync()
+    private val server = ember._1
+    private val release = ember._2
 
-    def getPort(): Int = server.getAddress.getPort
+    def getPort(): Int = server.addressIp4s.port.value
 
-    def stop(): Unit = server.stop(0)
+    def stop(): Unit = release.unsafeRunSync()
+  }
 
-    override def handle(t: HttpExchange): Unit = try {
-      val h: java.util.List[String] =
-        t.getRequestHeaders.get("Content-encoding")
+  private val echoRoutes = HttpRoutes.of[IO] {
+    case req @ POST -> Root / "echo" =>
       val c: Compress =
-        if (h == null) None
-        else if (h.contains("gzip")) Gzip
-        else if (h.contains("deflate")) Deflate
-        else None
-      val msg = new Plumper(c).decompress(t.getRequestBody)
-      t.sendResponseHeaders(200, msg.length)
-      t.getResponseBody.write(msg.getBytes())
-      t.getResponseBody.close()
-    } catch {
-      case e: Exception =>
-        e.printStackTrace()
-        t.sendResponseHeaders(500, -1)
-    } finally {
-      t.close()
-    }
+        req.headers.headers
+          .find(_.name.toString.equalsIgnoreCase("content-encoding"))
+          .map(_.value) match {
+          case Some("gzip")    => Compress.Gzip
+          case Some("deflate") => Compress.Deflate
+          case _               => Compress.None
+        }
+      req.body.compile.to(Array).flatMap { compressed =>
+        IO(new Plumper(c).decompress(new ByteArrayInputStream(compressed))).flatMap(Ok(_))
+      }
   }
 
   /**
@@ -56,9 +61,9 @@ object ServerUtils {
 
     private def wrap(is: InputStream): InputStream =
       c match {
-        case None    => is
-        case Gzip    => new GZIPInputStream(is)
-        case Deflate => new InflaterInputStream(is)
+        case Compress.None    => is
+        case Compress.Gzip    => new GZIPInputStream(is)
+        case Compress.Deflate => new InflaterInputStream(is)
       }
 
     def decompress(compressed: InputStream): String = {


### PR DESCRIPTION
Hi Haoyi,

This is part of the _Scala Native support for `requests-scala`_ project.

I have some good news for you that I've passed major tests in `requests.RequestTests` for the `HttpClient` on Scala Native. I'm currently waiting for Lorenzo to release a new version of `scala-native-crypto`. Once that's out, we'll be very close to achieving our final goal of building `requests` for Scala Native.

Regarding our current progress, there're only two barriers left holding us back, both of which I've addressed in this PR.

1. Runtime reflections: Scala Native doesn't support runtime reflection yet. Consequently, mechanisms like `httpClient.getClass()` and `.getDeclaredField()` definitely fail in Scala Native version.
   - Luckily, only `closeHttpClient` is affected.
   - I created a `CompatUtil` object, and split it into two directories `src-legacy` and `src-modern` with different implementations.
   - The build tool is configured to include `src-modern` for JDK 21+ and Scala Native, while `src-legacy` is only used for those JDK older than 21.
2. `ServerUtils.EchoServer`: The previous implementation of `EchoServer` relied `com.sun.net.httpserver.{HttpExchange, HttpHandler, HttpServer}`, which also doesn't work on the Scala Native platform.
   - I've introduced `http4s` and `http4s-ember-server` as test only deps, which work seamlessly across JVM, Scala Native, Scala JS.
   - By re-implementing `EchoServer` this way, we don't have to skip any tests to achieve the full Scala Native support.

Note that these commits are based on the previous PR #222, so we might need to merge that one first. I'll keep an eye on this and rebase if any conflicts arise after the merge of the previous PR.

Looking forward to hearing your thoughts!

Regards,
Lanqing