### PR TITLE
fix: apply readTimeout to response body reads

### DIFF
--- a/requests/src/requests/Requester.scala
+++ b/requests/src/requests/Requester.scala
@@ -424,7 +424,9 @@ case class Requester(verb: String, sess: BaseSession) {
           maxRedirects > 0
         ) {
           val out = new ByteArrayOutputStream()
-          Util.transferTo(response.body, out)
+          Util.withReadTimeout(response.body, readTimeout, url, connectTimeout) { is =>
+            Util.transferTo(is, out)
+          }
           val bytes = out.toByteArray
   
           val current = Response(
@@ -481,11 +483,13 @@ case class Requester(verb: String, sess: BaseSession) {
             if (upperCaseVerb == "HEAD") f(new ByteArrayInputStream(Array()))
             else if (stream != null) {
               try
-                f(
-                  if (deGzip) new GZIPInputStream(stream)
-                  else if (deDeflate) new InflaterInputStream(stream)
-                  else stream,
-                )
+                Util.withReadTimeout(stream, readTimeout, url, connectTimeout) { s =>
+                  f(
+                    if (deGzip) new GZIPInputStream(s)
+                    else if (deDeflate) new InflaterInputStream(s)
+                    else s,
+                  )
+                }
               finally if (!keepAlive) stream.close()
             } else {
               f(new ByteArrayInputStream(Array()))

--- a/requests/src/requests/Util.scala
+++ b/requests/src/requests/Util.scala
@@ -52,7 +52,8 @@ object Util {
           }
       } finally {
         cancelTask.cancel(false)
-        if (!timedOut) Thread.interrupted()
+        // Always clear: watchdog interrupts the caller on timeout; leave no sticky flag.
+        Thread.interrupted()
       }
     }
   }

--- a/requests/src/requests/Util.scala
+++ b/requests/src/requests/Util.scala
@@ -1,12 +1,62 @@
 package requests
 
-import java.io.{FileInputStream, InputStream, OutputStream}
+import java.io.{FileInputStream, InputStream, InterruptedIOException, OutputStream}
 import java.net.URLEncoder
 import java.security.cert.X509Certificate
+import java.util.concurrent.{Executors, TimeUnit}
 
 import javax.net.ssl.{KeyManagerFactory, SSLContext, TrustManager, X509TrustManager}
 
 object Util {
+  private val readTimeoutScheduler = Executors.newSingleThreadScheduledExecutor(r => {
+    val t = new Thread(r, "requests-scala-read-timeout")
+    t.setDaemon(true)
+    t
+  })
+
+  private[requests] def withReadTimeout[T](
+      is: InputStream,
+      readTimeoutMs: Int,
+      url: String,
+      connectTimeout: Int,
+  )(f: InputStream => T): T = {
+    if (readTimeoutMs <= 0) f(is)
+    else {
+      val callerThread = Thread.currentThread()
+      @volatile var timedOut = false
+      val cancelTask = readTimeoutScheduler.schedule(
+        new Runnable {
+          def run(): Unit = {
+            timedOut = true
+            callerThread.interrupt()
+            try is.close()
+            catch { case _: Throwable => }
+          }
+        },
+        readTimeoutMs,
+        TimeUnit.MILLISECONDS,
+      )
+      try {
+        f(is)
+      } catch {
+        case e @ (_: InterruptedException | _: InterruptedIOException) =>
+          if (timedOut) throw new TimeoutException(url, readTimeoutMs, connectTimeout)
+          else throw e
+        case e: java.io.IOException if timedOut =>
+          throw new TimeoutException(url, readTimeoutMs, connectTimeout)
+        case e: Throwable =>
+          Option(e.getCause) match {
+            case Some(_: InterruptedException | _: InterruptedIOException) if timedOut =>
+              throw new TimeoutException(url, readTimeoutMs, connectTimeout)
+            case _ => throw e
+          }
+      } finally {
+        cancelTask.cancel(false)
+        if (!timedOut) Thread.interrupted()
+      }
+    }
+  }
+
   def transferTo(
       is: InputStream,
       os: OutputStream,

--- a/requests/test/src/requests/ReadTimeoutTests.scala
+++ b/requests/test/src/requests/ReadTimeoutTests.scala
@@ -1,0 +1,19 @@
+package requests
+
+import utest._
+
+object ReadTimeoutTests extends TestSuite {
+  val tests = Tests {
+    test("readBodyStall") {
+      ServerUtils.usingStallServer() { port =>
+        val start = System.nanoTime()
+        intercept[TimeoutException] {
+          requests.get(s"http://127.0.0.1:$port/stall", readTimeout = 500)
+        }
+        val elapsedMs = (System.nanoTime() - start) / 1000000
+        assert(elapsedMs >= 400)
+        assert(elapsedMs < 3000)
+      }
+    }
+  }
+}

--- a/requests/test/src/requests/ServerUtils.scala
+++ b/requests/test/src/requests/ServerUtils.scala
@@ -15,6 +15,23 @@ object ServerUtils {
     finally server.stop()
   }
 
+  /** Sends response headers then stalls without sending the body (issue #229 repro). */
+  def usingStallServer(claimedBodySize: Long = 1024 * 1024)(f: Int => Unit): Unit = {
+    val server = HttpServer.create(new InetSocketAddress(0), 0)
+    server.createContext(
+      "/stall",
+      new HttpHandler {
+        override def handle(exchange: HttpExchange): Unit = {
+          exchange.sendResponseHeaders(200, claimedBodySize)
+        }
+      },
+    )
+    server.setExecutor(null)
+    server.start()
+    try f(server.getAddress.getPort)
+    finally server.stop(0)
+  }
+
   private class EchoServer extends HttpHandler {
     private val server: HttpServer =
       HttpServer.create(new InetSocketAddress(0), 0)


### PR DESCRIPTION
## Summary

- `readTimeout` previously only applied during header reception via `HttpRequest.timeout()`; once headers arrived, body `InputStream.read()` calls could block indefinitely (JDK behavior, see JDK-8258397).
- Add a watchdog in `Util.withReadTimeout` that closes the body stream after `readTimeout` elapses, unblocking stalled reads and throwing `TimeoutException`.
- Apply the watchdog around all response body reads in `Requester` (normal responses and redirect body buffering).

Fixes #229

## Test plan

- [x] `./mill 'requests.jvm[2.13.15].test' -o 'requests.ReadTimeoutTests.readBodyStall'` — local stall server sends headers then never sends body; request times out in ~500ms
- [x] `./mill 'requests.jvm[2.13.15].test' -o 'requests.ResourceLeakTests'` — no regression in client reuse/leak tests
- [x] `./mill 'requests.jvm[2.13.15].test' -o 'requests.ModelTests'` — no regression
- [x] `./mill 'requests.jvm[2.13.15].mimaReportBinaryIssues'` — binary compatibility check passed
- [x] Prove-it (unfixed): `readBodyStall` still running after 8s (`STILL_RUNNING_AFTER_8s=bug_confirmed`)
- [ ] CI (httpbin/docker tests require Docker in CI)